### PR TITLE
Simple Homepage Backend 단독 기동 시 Validator 관련 Dependency 추가 필요

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
+			<version>1.7</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springmodules</groupId>
+			<artifactId>spring-modules-validation</artifactId>
+			<version>0.8</version>
+		</dependency>
+
+		<dependency>
 			<groupId>taglibs</groupId>
 			<artifactId>standard</artifactId>
 			<version>1.1.2</version>


### PR DESCRIPTION
pom.xml
Simple Homepage Backend 단독 기동 시 Validator 관련 Dependency 추가필요합니다.

                <dependency>
			<groupId>commons-validator</groupId>
			<artifactId>commons-validator</artifactId>
			<version>1.7</version>
		</dependency>

		<dependency>
			<groupId>org.springmodules</groupId>
			<artifactId>spring-modules-validation</artifactId>
			<version>0.8</version>
		</dependency>