### PR TITLE
리액트에서 사이트관리자에 접근하는 토큰값 위변조 방지용으로 서버에서 비교하는 메서드 추가

### DIFF
--- a/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
+++ b/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
@@ -32,6 +32,7 @@ import egovframework.let.utl.sim.service.EgovFileScrty;
  *  수정일      수정자      수정내용
  *  -------            --------        ---------------------------
  *  2023.04.15  김일국     최초 생성
+ *  2023.04.20  김일국     리액트에서 사용할 공통인증메서드 추가
  *
  *  </pre>
  */
@@ -47,6 +48,25 @@ public class EgovSiteManagerApiController {
 	private ResultVO handleAuthError(ResultVO resultVO) {
 		resultVO.setResultCode(ResponseCode.AUTH_ERROR.getCode());
 		resultVO.setResultMessage(ResponseCode.AUTH_ERROR.getMessage());
+		return resultVO;
+	}
+	/**
+	 * 리액트에서 사이트관리자에 접근하는 토큰값 위변조 방지용으로 서버에서 비교한다.
+	 * @param map데이터: String old_password, new_password
+	 * @param request - 토큰값으로 인증된 사용자를 확인하기 위한 HttpServletRequest
+	 * @return result - JWT 토큰값 비교결과 코드와 메세지
+	 * @exception Exception
+	 */
+	@PostMapping(value = "/uat/esm/jwtAuthAPI.do")
+	public ResultVO jwtAuthentication(HttpServletRequest request) throws Exception {
+		ResultVO resultVO = new ResultVO();
+		// Headers에서 Authorization 속성값에 발급한 토큰값이 정상인지 확인
+		if (!jwtVerification.isVerification(request)) {
+			resultVO = handleAuthError(resultVO); // 토큰 확인
+		}else{
+			resultVO.setResultCode(ResponseCode.SUCCESS.getCode());
+			resultVO.setResultMessage(ResponseCode.SUCCESS.getMessage());
+		}
 		return resultVO;
 	}
 	/**


### PR DESCRIPTION
## 수정 사유 Reason for modification
리액트 앱의 사이트관리단에 로컬 스토리지 비교만으로 보안이 약해서 토큰값 위변조로 접근을 방지할 서버용 메서드를 추가하였습니다.
소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
- EgovSiteManagerApiController.java 파일 라인60번에 서버와 클라이언트의 토큰 값을 비교하는 메서드 소스를 추가.
- 위 클래스의 패키지명 : egovframework.let.uat.esm.web
- @PostMapping(value = "/uat/esm/jwtAuthAPI.do") //추가한 URL매핑과 메서드(아래)
- public ResultVO jwtAuthentication(HttpServletRequest request) throws Exception { 구현 코드 생략... }

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 크롬 부메랑 RestAPI 플러그인으로 헤더에 Authorization 속성에 서버 토큰과 비교할 리액트의 토큰 값 입력 전(상단)과 후(하단) 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/233303053-2ec1ef4d-2853-4020-8ccc-022d934b4d4b.png)
- 리액트 앱 프런트엔드 소스도 수정 하겠습니다.