### PR TITLE
스웨그 화면상단에 Authorize버튼 추가 및 토큰값 입력하는 Authorization창 구현

### DIFF
--- a/src/main/java/egovframework/com/config/SwaggerConfig.java
+++ b/src/main/java/egovframework/com/config/SwaggerConfig.java
@@ -6,11 +6,14 @@ import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+//accessToken 입력 화면과 처리 라이브러리 추가(아래4줄)
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.service.*;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -27,8 +30,32 @@ public class SwaggerConfig {
 				.select()
 				.apis(RequestHandlerSelectors.any())
 				.paths(PathSelectors.any())
-				.build();	
+				.build()
+				.securityContexts(Arrays.asList(securityContext())) // 스웨그에서 컨텐츠 url 접근 시 인증처리를 위한 보안 규칙 호출
+                .securitySchemes(Arrays.asList(apiKey())); // 스웨그 화면상단에 토큰값 입력하는 창 구조 호출, 여기에 배열로 추가 apiKey메서드를 입력가능	
 	}
+	
+	// Authorization창에 Token값 입력 화면 구조 
+    private ApiKey apiKey() {
+        return new ApiKey("Authorization", "Authorization", "header");
+    }
+    // 스웨그에서 컨텐츠 url 접근 시 인증처리를 위한 보안 규칙 추가(아래)
+    private SecurityContext securityContext() {
+        return springfox
+                .documentation
+                .spi.service
+                .contexts
+                .SecurityContext
+                .builder()
+                .securityReferences(defaultAuth()).forPaths(PathSelectors.any()).build();
+    }
+    // 토큰 인증영역 배열리스트을 반환하는 매서드
+    List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything"); // 인증영역 객체 생성
+        AuthorizationScope[] authorizationScopeArray = new AuthorizationScope[1]; // 빈 배열 인증영역 객체 생성
+        authorizationScopeArray[0] = authorizationScope; // 배열변수에 인증영역 객체 등록
+        return Arrays.asList(new SecurityReference("Authorization", authorizationScopeArray)); // 여기에 배열로 추가 SecurityReference객체를 입력가능
+    }
 	
 	public ApiInfo apiInfo() {
 		return new ApiInfoBuilder()


### PR DESCRIPTION
## 수정 사유 Reason for modification
- 스웨그 http://localhost:8080/swagger-ui/index.html 화면에서 /uat/uia/actionLoginJWT.do 을 사용하여 인증 후 권한을 사용하는 다른 액션에서도 인증을 사용할 수 있도록 전송 Header 값에  Authorizate 속성 값을 추가 하는 기능이 필요 하였습니다.

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

- SwaggerConfig.java 파일 : 라인34~라인58까지 Authorization창에 [Token값을 입력하는 화면구현] 코드 추가

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 수정 전 : 스웨거 Try it out 창에서 로그인 하기(아래)
![image](https://user-images.githubusercontent.com/52336625/233911444-28e014cd-af07-49f7-801f-92f27ff47f01.png)
- 수정 전 : 스웨거 Try it out 창에서 서버 인증이 되었는지 확인하면 '인가된 사용자가 아닙니다.'  부분이 출력(아래)
![image](https://user-images.githubusercontent.com/52336625/233911696-917c5445-50dd-451d-abe8-af164aa61275.png)
- 수정 후 : 스웨거 상단 화면에 Authorize 버튼이 생성되어서, 모든 전송 Header에 토큰 값을 입력 할 수 있다.(아래)
![image](https://user-images.githubusercontent.com/52336625/233911907-e5440189-c55d-43d8-b22f-befdc84aaa26.png)
- 수정 후 : 위 Authorize 버튼에서 토큰 인증 후 스웨거 Try it out 창에서 서버 인증이 되었는지 확인하면 Header에 토큰 값이 포함되고, '성공했습니다.' 가 출력(아래)
![image](https://user-images.githubusercontent.com/52336625/233912267-deb169d6-1dcb-46e7-b984-6d4c3add0461.png)
