### PR TITLE
첨부파일 삭제 API POST로 변경

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovFileMngApiController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovFileMngApiController.java
@@ -7,8 +7,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.egovframe.rte.fdl.cryptography.EgovCryptoService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import egovframework.com.cmm.ResponseCode;
@@ -56,20 +56,16 @@ public class EgovFileMngApiController {
      * @return resultVO
      * @throws Exception
      */
-    @DeleteMapping(value ="/cmm/fms/deleteFileInfsAPI/{atchFileId}/{fileSn}.do")
-    public ResultVO deleteFileInf(HttpServletRequest request, @PathVariable("atchFileId") String atchFileId,
-    	@PathVariable("fileSn") String fileSn) throws Exception {
+    @PostMapping(value ="/cmm/fms/deleteFileInfsAPI.do")
+    public ResultVO deleteFileInf(HttpServletRequest request, @RequestBody FileVO fileVO) throws Exception {
     	ResultVO resultVO = new ResultVO();
     	
     	// 암호화된 atchFileId 를 복호화 (2022.12.06 추가) - 파일아이디가 유추 불가능하도록 조치
-    	atchFileId = atchFileId.replaceAll(" ", "+");
+    	String atchFileId = fileVO.getAtchFileId().replaceAll(" ", "+");
     	byte[] decodedBytes = Base64.getDecoder().decode(atchFileId);
     	String decodedFileId = new String(cryptoService.decrypt(decodedBytes,EgovFileDownloadController.ALGORITM_KEY));
     			
-    	FileVO fileVO = new FileVO();
-    	
     	fileVO.setAtchFileId(decodedFileId);
-    	fileVO.setFileSn(fileSn);
 
 		//Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

특정 암호화 알고리즘 키 사용 시 암호화된 attachFileId에 슬래쉬(/)가 들어가 DELETE 요청을 하였을 때 URL이 구분되어 첨부파일 삭제 시 에러가 발생.

EgovFileMngApiController의 deleteFileInf HTTP Method를 POST로 수정(59)
그에 따라 파라메터를 body로 받아오게 수정함(60)
FileVO에서 atchFileId 바로 추출(64)
기타 불필요한 코드 삭제

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video
**수정 전**

![스크린샷 2023-04-27 142740](https://user-images.githubusercontent.com/46992992/234777400-534ec314-7b90-4a4e-a852-867879d12c4e.png)

**삭제버튼 클릭(에러 발생)**
![스크린샷 2023-04-27 142809](https://user-images.githubusercontent.com/46992992/234777555-97643386-31b6-48ac-ab32-f52370fab203.png)

**수정 후(삭제완료)**
![스크린샷 2023-04-27 142914](https://user-images.githubusercontent.com/46992992/234777612-877ebe47-0357-46d6-9858-9088d854a6d2.png)

**삭제 확인**
![스크린샷 2023-04-27 142932](https://user-images.githubusercontent.com/46992992/234777665-45442f3d-d33c-43bd-b8e3-e3950cacf18d.png)
