### PR TITLE
Add Querydsl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,18 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 		</dependency>
 
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-jpa</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-apt</artifactId>
+				<scope>provided</scope>
+			</dependency>
+
+
+
 		<dependency>
 		    <groupId>org.apache.tomcat.embed</groupId>
 		    <artifactId>tomcat-embed-core</artifactId>
@@ -326,6 +338,9 @@
 		<finalName>sht_webapp</finalName>
 		<pluginManagement>
 			<plugins>
+
+
+
 				<plugin>
 					<groupId>org.apache.tomcat.maven</groupId>
 					<artifactId>tomcat7-maven-plugin</artifactId>
@@ -384,6 +399,47 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
+
+			<plugin>
+				<groupId>com.mysema.maven</groupId>
+				<artifactId>apt-maven-plugin</artifactId>
+				<version>1.1.3</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>process</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+							<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+						</configuration>
+
+					</execution>
+
+					<execution>
+						<id>generate-test-entities</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>test-process</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/generated-test-sources</outputDirectory>
+							<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+							<options>
+								<querydsl.generatedAnnotationClass>javax.annotation.Generated</querydsl.generatedAnnotationClass>
+							</options>
+						</configuration>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>com.querydsl</groupId>
+						<artifactId>querydsl-apt</artifactId>
+						<version>4.4.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+
 			<!-- EMMA -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/egovframework/study/jpa/JpaTest.java
+++ b/src/test/java/egovframework/study/jpa/JpaTest.java
@@ -1,4 +1,4 @@
-package egovframework.study;
+package egovframework.study.jpa;
 
 import egovframework.study.jpa.domain.Locker;
 import egovframework.study.jpa.domain.Member;

--- a/src/test/java/egovframework/study/jpa/QueryDslTest.java
+++ b/src/test/java/egovframework/study/jpa/QueryDslTest.java
@@ -1,0 +1,66 @@
+package egovframework.study.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import egovframework.study.jpa.domain.Member;
+import egovframework.study.jpa.domain.QMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * fileName       : QueryDslTest
+ * author         : crlee
+ * date           : 2023/05/21
+ * description    : Query DSL 테스트 코드
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/05/21        crlee       최초 생성
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest // 데이터 JPA 테스트 어노테이션
+@Transactional // 트랜잭션 관리 어노테이션
+public class QueryDslTest {
+
+    @Autowired
+    private TestEntityManager entityManager; // EntityManager를 테스트하기 위한 객체
+
+    private JPAQueryFactory queryFactory; // Querydsl을 사용하기 위한 QueryFactory
+
+    @BeforeEach
+    public void setup() {
+        queryFactory = new JPAQueryFactory(entityManager.getEntityManager());
+    }
+
+    @Test
+    public void testQuerydsl() {
+        // Given
+        for (int i=1 ; i<30 ; i++ ){
+            entityManager.persist(Member.builder()
+                    .id("member_id"+i)
+                    .username("member_name"+i)
+                    .age(i)
+                    .build());
+        }
+        // When
+
+        QMember member = QMember.member;
+        List<Member> members = queryFactory
+                .selectFrom(member)
+                .where(member.age.between(10, 15))
+                .orderBy(member.username.asc())
+                .fetch();
+
+        // Then
+        assertThat(members.size()).isEqualTo(6);
+        assertThat(members.get(0).getUsername()).isEqualTo("member_name10");
+        assertThat(members.get(5).getUsername()).isEqualTo("member_name15");
+    }
+}

--- a/src/test/java/egovframework/study/jpa/QueryDslTest.java
+++ b/src/test/java/egovframework/study/jpa/QueryDslTest.java
@@ -1,10 +1,10 @@
 package egovframework.study.jpa;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import egovframework.study.jpa.domain.Member;
 import egovframework.study.jpa.domain.QMember;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -25,14 +25,14 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest // 데이터 JPA 테스트 어노테이션
-@Transactional // 트랜잭션 관리 어노테이션
+@DataJpaTest
+@Transactional
 public class QueryDslTest {
 
     @Autowired
-    private TestEntityManager entityManager; // EntityManager를 테스트하기 위한 객체
+    private TestEntityManager entityManager;
 
-    private JPAQueryFactory queryFactory; // Querydsl을 사용하기 위한 QueryFactory
+    private JPAQueryFactory queryFactory;
 
     @BeforeEach
     public void setup() {
@@ -40,16 +40,9 @@ public class QueryDslTest {
     }
 
     @Test
-    public void testQuerydsl() {
-        // Given
-        for (int i=1 ; i<30 ; i++ ){
-            entityManager.persist(Member.builder()
-                    .id("member_id"+i)
-                    .username("member_name"+i)
-                    .age(i)
-                    .build());
-        }
-        // When
+    @DisplayName("QueryDSL로 selectList")
+    public void testSelectList() {
+        insertTestMembers(30);
 
         QMember member = QMember.member;
         List<Member> members = queryFactory
@@ -58,9 +51,62 @@ public class QueryDslTest {
                 .orderBy(member.username.asc())
                 .fetch();
 
-        // Then
         assertThat(members.size()).isEqualTo(6);
         assertThat(members.get(0).getUsername()).isEqualTo("member_name10");
         assertThat(members.get(5).getUsername()).isEqualTo("member_name15");
     }
+
+    @Test
+    @DisplayName("QueryDSL로 selectList - 동적")
+    public void testSelectListDynamic() throws CloneNotSupportedException {
+        insertTestMembers(30);
+
+        QMember member = QMember.member;
+        BooleanBuilder builder = createAgeNameFilter(member, 10);
+
+        List<Member> members = queryFactory
+                .selectFrom(member)
+                .where(builder)
+                .fetch();
+
+        assertThat(members.size()).isEqualTo(1);
+        assertThat(members.get(0).getUsername()).isEqualTo("member_name10");
+        assertThat(members.get(0).getAge()).isEqualTo(10);
+    }
+    private BooleanBuilder createAgeNameFilter(QMember member, int age) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (age == 10) {
+            builder.and(member.age.eq(10));
+        } else {
+            builder.and(member.age.eq(15)).or(member.username.contains("member_name"));
+        }
+        return builder;
+    }
+    @Test
+    @DisplayName("QueryDSL로 selectOne")
+    public void testSelectOne() {
+        insertTestMembers(5);
+
+        QMember member = QMember.member;
+        Member members = queryFactory
+                .selectFrom(member)
+                .where(member.age.eq(3))
+                .fetchOne();
+
+        assertThat(members.getUsername()).isEqualTo("member_name3");
+        assertThat(members.getAge()).isEqualTo(3);
+    }
+
+    private void insertTestMembers(int count) {
+        for (int i = 1; i <= count; i++) {
+            entityManager.persist(Member.builder()
+                    .id("member_id" + i)
+                    .username("member_name" + i)
+                    .age(i)
+                    .build());
+        }
+    }
+
+
 }

--- a/src/test/java/egovframework/study/jpa/domain/Locker.java
+++ b/src/test/java/egovframework/study/jpa/domain/Locker.java
@@ -30,6 +30,7 @@ public class Locker {
 
     private String name;
 
+    @Builder.Default
     @OneToOne(mappedBy = "locker" , cascade = CascadeType.PERSIST)
     private Member member = new Member();
 }

--- a/src/test/java/egovframework/study/jpa/domain/Team.java
+++ b/src/test/java/egovframework/study/jpa/domain/Team.java
@@ -31,7 +31,7 @@ public class Team {
     private String id;
 
     private String name;
-
+    @Builder.Default
     @OneToMany(mappedBy = "team")
     private List<Member> members = new ArrayList<Member>();
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [x] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

Spring Data JPA가 기본적으로 제공하는 CRUD를 사용하더라도, 원하는 데이터를 얻기 위해서는 JPQL을 사용하게 됩다.
간단한 로직을 작성하는데 큰 문제는 없지만, 복잡한 로직의 경우 개행이 포함된 문자열이 상당히 길어진다.

JPQL 문자열에 오타, 문법적 오류가 존재하는 경우 어플리케이션 로딩 시점에 이를 발견할 수 없다.

이러함 문제를 해소하는데 기여하는게 바로 Querydsl이다.

- 문자가 아닌 코드로 쿼리를 작성함으로써, 컴파일 시점에 문법 오류를 쉽게 확인할 수 있다.
- 동적인 쿼리 작성이 편리하다.
- 쿼리 작성 시 제약 조건 등을 메서드 추출을 통해 재사용할 수 있다.
- 데이터 베이스 종속성이 없다.
- 쿼리 빌더 패턴 제공

- Q 클래스 사용시 target source 설정
![image](https://github.com/eGovFramework/egovframe-template-simple-backend/assets/30648191/122a15e0-4af0-48b0-b8ba-23edeced4c30)

## 

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
![image](https://github.com/eGovFramework/egovframe-template-simple-backend/assets/30648191/13425bd1-e161-4ce6-a110-e633f088aebb)
