### PR TITLE
Automatically adding the URL of methods with the SecurityPass annotation to the AUTH_WHITELIST

### DIFF
--- a/src/main/java/egovframework/com/cmm/annotation/SecurityPass.java
+++ b/src/main/java/egovframework/com/cmm/annotation/SecurityPass.java
@@ -1,0 +1,25 @@
+package egovframework.com.cmm.annotation;
+
+
+import egovframework.com.security.pass.SecurityPassConst;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+/**
+ * fileName       : SecurityPass
+ * author         : crlee
+ * date           : 2023/08/04
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/08/04        crlee       최초 생성
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SecurityPass {
+    String[] role() default {SecurityPassConst.ALL};
+}

--- a/src/main/java/egovframework/com/security/SecurityConfig.java
+++ b/src/main/java/egovframework/com/security/SecurityConfig.java
@@ -2,6 +2,8 @@ package egovframework.com.security;
 
 import egovframework.com.jwt.JwtAuthenticationEntryPoint;
 import egovframework.com.jwt.JwtAuthenticationFilter;
+import egovframework.com.security.pass.SecurityPassUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -33,18 +35,9 @@ public class SecurityConfig {
     private String[] AUTH_WHITELIST = {
             "/",
             "/login/**",
-            "/uat/uia/actionLoginJWT.do",//JWT 로그인
-            "/uat/uia/actionLoginAPI.do",//일반 로그인
             "/cmm/main/**.do", // 메인페이지
             "/cmm/fms/FileDown.do", //파일 다운로드
             "/cmm/fms/getImage.do", //갤러리 이미지보기
-            "/cop/smt/sim/egovIndvdlSchdulManageDailyListAPI.do", //일별 일정 조회
-            "/cop/smt/sim/egovIndvdlSchdulManageWeekListAPI.do", //주간 일정 조회
-            "/cop/smt/sim/egovIndvdlSchdulManageDetailAPI.do", //일정 상세조회
-
-            "/cop/bbs/selectUserBBSMasterInfAPI.do", //게시판 마스터 상세 조회
-            "/cop/bbs/selectBoardListAPI.do", //게시판 목록조회
-            "/cop/bbs/selectBoardArticleAPI.do", //게시물 상세조회
 
             /* swagger v2 */
             "/v2/api-docs",
@@ -56,6 +49,9 @@ public class SecurityConfig {
     private static final String[] ORIGINS_WHITELIST = {
             "http://localhost:3000",
     };
+
+    @Autowired
+    SecurityPassUtils securityPassUtils;
 
     @Bean
     public JwtAuthenticationFilter authenticationTokenFilterBean() throws Exception {
@@ -79,11 +75,13 @@ public class SecurityConfig {
     }
     @Bean
     protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        String[] permitAllUrls = securityPassUtils.getUrls();
 
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .antMatchers(AUTH_WHITELIST).permitAll()
+                        .antMatchers(permitAllUrls).permitAll()
                         .anyRequest().authenticated()
                 ).sessionManagement((sessionManagement) ->
                     sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/egovframework/com/security/pass/SecurityPassConfig.java
+++ b/src/main/java/egovframework/com/security/pass/SecurityPassConfig.java
@@ -1,0 +1,23 @@
+package egovframework.com.security.pass;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * fileName       : SecurityPassConfig
+ * author         : crlee
+ * date           : 2023/08/04
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/08/04        crlee       최초 생성
+ */
+@Configuration
+public class SecurityPassConfig {
+
+    @Bean
+    protected SecurityPassUtils securityUtils(){
+        return new SecurityPassUtils();
+    }
+}

--- a/src/main/java/egovframework/com/security/pass/SecurityPassConst.java
+++ b/src/main/java/egovframework/com/security/pass/SecurityPassConst.java
@@ -1,0 +1,15 @@
+package egovframework.com.security.pass;
+
+/**
+ * fileName       : SecurityConst
+ * author         : crlee
+ * date           : 2023/08/04
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/08/04        crlee       최초 생성
+ */
+public class SecurityPassConst {
+    public static final String ALL = "ALL";
+}

--- a/src/main/java/egovframework/com/security/pass/SecurityPassUtils.java
+++ b/src/main/java/egovframework/com/security/pass/SecurityPassUtils.java
@@ -1,0 +1,83 @@
+package egovframework.com.security.pass;
+
+import egovframework.com.cmm.annotation.SecurityPass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * fileName       : SecurityUtils
+ * author         : crlee
+ * date           : 2023/08/04
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/08/04        crlee       최초 생성
+ */
+public class SecurityPassUtils {
+    @Autowired
+    ApplicationContext applicationContext;
+
+    public String[] getUrls(){
+        return getUrls(SecurityPassConst.ALL);
+    }
+    public String[] getUrls(String roleType){
+        List<String> auth_whitelists = new ArrayList<>();
+        try{
+            auth_whitelists = searchMappingUrls(roleType);
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+
+        return auth_whitelists.toArray(new String[0]);
+    }
+    private List<String> searchMappingUrls(String roleType) throws NoSuchMethodException, SecurityException, InvocationTargetException, IllegalAccessException {
+
+        List<String> auth_whitelists = new ArrayList<>();
+
+        List<Class<? extends Annotation>> mappingAnnotations = Arrays.asList(
+                GetMapping.class,
+                PostMapping.class,
+                PutMapping.class,
+                DeleteMapping.class,
+                PatchMapping.class
+        );
+        List<Class> classes = findController();
+        for (Class clazz : classes) {
+            for(Method method : clazz.getMethods()){
+                if (method.isAnnotationPresent(SecurityPass.class)) {
+                    String[] roles = (String[]) method.getAnnotation(SecurityPass.class).getClass().getMethod("role").invoke(method.getAnnotation(SecurityPass.class));
+                    if( Arrays.asList(roles).contains(roleType) ){
+                        for (Class<? extends Annotation> annotationClass : mappingAnnotations) {
+                            if( method.isAnnotationPresent(annotationClass) ){
+                                String[] values = (String[]) method.getAnnotation(annotationClass).getClass().getMethod("value").invoke(method.getAnnotation(annotationClass));
+                                auth_whitelists.addAll(Arrays.asList(values));
+                            };
+                        }
+                    }
+
+                }
+            }
+        }
+        return auth_whitelists;
+    }
+
+    private List<Class> findController(){
+        List<Class> classes = new ArrayList<>();
+        Map<String, Object> beansWithControllerAnnotation = applicationContext.getBeansWithAnnotation(Controller.class);
+        for(Object controller : beansWithControllerAnnotation.values()) {
+            classes.add(controller.getClass());
+        }
+        return classes;
+    }
+}

--- a/src/main/java/egovframework/let/cop/bbs/web/EgovBBSManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/web/EgovBBSManageApiController.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 
+import egovframework.com.cmm.annotation.SecurityPass;
 import org.egovframe.rte.fdl.cryptography.EgovCryptoService;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
@@ -123,6 +124,7 @@ public class EgovBBSManageApiController {
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
 			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
 	})
+	@SecurityPass
 	@PostMapping(value = "/cop/bbs/selectUserBBSMasterInfAPI.do", consumes = MediaType.APPLICATION_JSON_VALUE)
 	public ResultVO selectUserBBSMasterInf(@RequestBody BoardMasterVO searchVO)
 		throws Exception {
@@ -155,6 +157,7 @@ public class EgovBBSManageApiController {
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
 			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
 	})
+	@SecurityPass
 	@PostMapping(value = "/cop/bbs/selectBoardListAPI.do", consumes = MediaType.APPLICATION_JSON_VALUE)
 	public ResultVO selectBoardArticles(@RequestBody BoardVO boardVO, @AuthenticationPrincipal LoginVO user)
 		throws Exception {
@@ -208,6 +211,7 @@ public class EgovBBSManageApiController {
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
 			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
 	})
+	@SecurityPass
 	@PostMapping(value = "/cop/bbs/selectBoardArticleAPI.do")
 	public ResultVO selectBoardArticle(@RequestBody BoardVO boardVO,@AuthenticationPrincipal LoginVO user)
 		throws Exception {

--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 
+import egovframework.com.cmm.annotation.SecurityPass;
 import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
 import org.egovframe.rte.fdl.cryptography.EgovCryptoService;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
@@ -246,6 +247,7 @@ public class EgovIndvdlSchdulManageApiController {
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
+	@SecurityPass
 	@PostMapping(value = "/cop/smt/sim/egovIndvdlSchdulManageDetailAPI.do")
 	public ResultVO EgovIndvdlSchdulManageDetail(
 		@RequestBody Map<String, Object> commandMap,
@@ -443,6 +445,7 @@ public class EgovIndvdlSchdulManageApiController {
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
 			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
 	})
+	@SecurityPass
 	@PostMapping(value = "/cop/smt/sim/egovIndvdlSchdulManageDailyListAPI.do")
 	public ResultVO EgovIndvdlSchdulManageDailyList(
 		@RequestBody Map<String, Object> commandMap)
@@ -517,6 +520,7 @@ public class EgovIndvdlSchdulManageApiController {
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
 			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
 	})
+	@SecurityPass
 	@PostMapping(value = "/cop/smt/sim/egovIndvdlSchdulManageWeekListAPI.do")
 	public ResultVO EgovIndvdlSchdulManageWeekList(
 		@RequestBody Map<String, Object> commandMap)

--- a/src/main/java/egovframework/let/uat/uia/web/EgovLoginApiController.java
+++ b/src/main/java/egovframework/let/uat/uia/web/EgovLoginApiController.java
@@ -6,7 +6,7 @@ import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cmm.annotation.SecurityPass;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -89,6 +89,7 @@ public class EgovLoginApiController {
 			@ApiResponse(responseCode = "200", description = "로그인 성공"),
 			@ApiResponse(responseCode = "300", description = "로그인 실패")
 	})
+	@SecurityPass
 	@PostMapping(value = "/uat/uia/actionLoginAPI.do", consumes = {MediaType.APPLICATION_JSON_VALUE , MediaType.TEXT_HTML_VALUE})
 	public HashMap<String, Object> actionLogin(@RequestBody LoginVO loginVO, HttpServletRequest request) throws Exception {
 		HashMap<String,Object> resultMap = new HashMap<String,Object>();
@@ -111,7 +112,10 @@ public class EgovLoginApiController {
 		return resultMap;
 
 	}
-
+	@GetMapping(value = "/test")
+	public String test(){
+		return "!!!";
+	}
 	@Operation(
 			summary = "JWT 로그인",
 			description = "JWT 로그인 처리",
@@ -121,6 +125,7 @@ public class EgovLoginApiController {
 			@ApiResponse(responseCode = "200", description = "로그인 성공"),
 			@ApiResponse(responseCode = "300", description = "로그인 실패")
 	})
+	@SecurityPass()
 	@PostMapping(value = "/uat/uia/actionLoginJWT.do")
 	public HashMap<String, Object> actionLoginJWT(@RequestBody LoginVO loginVO, HttpServletRequest request, ModelMap model) throws Exception {
 		HashMap<String, Object> resultMap = new HashMap<String, Object>();

--- a/src/test/java/egovframework/com/security/pass/SecurityPassUtilsTest.java
+++ b/src/test/java/egovframework/com/security/pass/SecurityPassUtilsTest.java
@@ -1,0 +1,64 @@
+package egovframework.com.security.pass;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+
+/**
+ * fileName       : SecurityPassUtilsTest
+ * author         : crlee
+ * date           : 2023/08/04
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/08/04        crlee       최초 생성
+ */
+@SpringBootTest(classes = {
+    TestController.class,
+    Test2Controller.class,
+    SecurityPassUtils.class
+})
+public class SecurityPassUtilsTest {
+
+    @Autowired
+    SecurityPassUtils securityPassUtils;
+
+    @Test
+    @DisplayName("모든 권한 테스트")
+    public void getAllUrlsTest(){
+        String[] getAllUrls = securityPassUtils.getUrls();
+        String[] expectUrls = {"/test/post", "/test/put", "/test/delete","/test/get"};
+        chkArr( getAllUrls , expectUrls );
+    }
+    @Test
+    @DisplayName("ROLE1 권한 테스트")
+    public void getRole1UrlsTest(){
+        String[] getAllUrls = securityPassUtils.getUrls("ROLE1");
+        String[] expectUrls = {"/test/get2", "/test/delete2" ,"/test2/post"};
+        chkArr( getAllUrls , expectUrls );
+    }
+    @Test
+    @DisplayName("ROLE2 권한 테스트")
+    public void getRole2UrlsTest(){
+        String[] getAllUrls = securityPassUtils.getUrls("ROLE2");
+        String[] expectUrls = {"/test/get2"};
+        chkArr( getAllUrls , expectUrls );
+    }
+    @Test
+    @DisplayName("없는 권한 테스트")
+    public void nullTest(){
+        String[] getAllUrls = securityPassUtils.getUrls("ROLE33333");
+        String[] expectUrls = {};
+        chkArr( getAllUrls , expectUrls );
+    }
+    public void chkArr(String[] arr1,String[] arr2){
+        Arrays.sort(arr1);
+        Arrays.sort(arr2);
+        Assertions.assertArrayEquals( arr1 , arr2 );
+    }
+}

--- a/src/test/java/egovframework/com/security/pass/Test2Controller.java
+++ b/src/test/java/egovframework/com/security/pass/Test2Controller.java
@@ -1,0 +1,21 @@
+package egovframework.com.security.pass;
+
+import egovframework.com.cmm.annotation.SecurityPass;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+public class Test2Controller {
+
+    @GetMapping(value = "/test2/get")
+    public String getTest(){
+        return "Hellow Egov!";
+    }
+
+
+    @SecurityPass(role = "ROLE1")
+    @PostMapping(value = "/test2/post")
+    public String postTest(){
+        return "Hellow Egov!";
+    }
+}

--- a/src/test/java/egovframework/com/security/pass/TestController.java
+++ b/src/test/java/egovframework/com/security/pass/TestController.java
@@ -1,0 +1,40 @@
+package egovframework.com.security.pass;
+
+import egovframework.com.cmm.annotation.SecurityPass;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class TestController {
+
+    @SecurityPass
+    @GetMapping(value = "/test/get")
+    public String getTest(){
+        return "Hellow Egov!";
+    }
+    @SecurityPass( role = {"ROLE1","ROLE2"} )
+    @GetMapping(value = "/test/get2")
+    public String getTest2(){
+        return "Hellow Egov!";
+    }
+    @SecurityPass
+    @PostMapping(value = "/test/post")
+    public String postTest(){
+        return "Hellow Egov!";
+    }
+    @SecurityPass
+    @PutMapping(value = "/test/put")
+    public String putTest(){
+        return "Hellow Egov!";
+    }
+    @SecurityPass
+    @DeleteMapping(value = "/test/delete")
+    public String deleteTest1(){
+        return "Hellow Egov!";
+    }
+    @SecurityPass( role = "ROLE1" )
+    @DeleteMapping(value = "/test/delete2")
+    public String deleteTest2(){
+        return "Hellow Egov!";
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [x] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

기존에는 인증 예외 API를 SecurityConfig의 AUTH_WHITELIST로 관리하고 있었습니다.
그러나 이러한 방식은 
- 컨트롤러의 메서드만을 보고서 해당 메서드가 인증이 필요한지 아닌지 파악하기 어렵다.
- 권한별로 API를 관리할 경우, 시스템이 확장되는 경우에 따라 AUTH_WHITELIST의 코드양이 늘어난다.
- 같은 API문자열을 Controller, SecurityConfig에서 중복으로 관리해야 한다.
등의 문제점이 있습니다.
```java
@PostMapping(value = "/user/login.do")
public HashMap<String, Object> actionLogin() throws Exception {
    // Login Action
}  //----> 메서드만을 보고서는 인증이 필요한지 아닌지 확인 할 수 없음
```
```java
private String[] AUTH_WHITELIST = {
        "/",
        "/user/login.do", //-----> 중복으로 관리해야함, 시스템이 확장할수록 점점 늘어남
};

@Bean
protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    return http
    .authorizeHttpRequests(authorize -> authorize
        .antMatchers(AUTH_WHITELIST).permitAll()
        .anyRequest().authenticated()
    )
    .build();
}

```
이를 해결하기 위해 Controller 메서드에 인증 예외관련 어노테이션을 붙이려고 합니다.
이미 스프링에서는 이미 인증,권한에 대한 어노테이션 있지만
- PreAuthorize("hasRole('ROLE_USER')은 문자열을 작성하기 때문에 컴파일시 문법 오류를 체크할 수 없습니다.
- PermitAll은 spring-security 구성에서 authorizeHttpRequests()를 사용할 수 없습니다.
- PermitAll은 스프링 보안 구성에서 HttpRequests()를 인증하기 위한 특수 설정을 지정하거나 제거해야 합니다.
- EnableGlobalMethodSecurity(jsr250Enabled = true),@EnableMethodSecurity(securedEnabled = true ,  securedEnabled = true)와 같은 설정이 추가적으로 필요

```java
@PermitAll
//@Secured({"ROLE_USER","ROLE_ADMIN"})
//@PreAuthorize("hasRole('ROLE_USER') and hasRole('ROLE_ADMIN')")
public HashMap<String, Object> actionLogin() throws Exception {
// Login Action
}
```
```java
@EnableGlobalMethodSecurity(jsr250Enabled = true)
//@EnableMethodSecurity(securedEnabled = true ,  securedEnabled = true).  ---> 특별한 설정이 필요함
public class SecurityConfig {
    @Bean
    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        return http
                .csrf(AbstractHttpConfigurer::disable)
                //.authorizeHttpRequests(authorize -> authorize
                //        .antMatchers(AUTH_WHITELIST).permitAll()  -> AUTH_WHITELIST를 동시에 사용할 수 없고, 사용하기 위해서는 특별한 설정이 필요함
                //        .anyRequest().authenticated()
                //)
                .build();
    }
}
```
위와 같은 문제점이 있기 때문에 보다 쉽게 사용할 수 있는 SecurityPass를 구현했습니다.

### SecurityPass
```java
//컨트롤러
@PostMapping(value = "/user/login.do")
@SecurityPass
public HashMap<String, Object> actionLogin() throws Exception {
    //login action
}
```
```java
// SecurityPassConfig
@Configuration
public class SecurityPassConfig {

    @Bean
    protected SecurityPassUtils securityPassUtils(){
        return new SecurityPassUtils();
    }
}
```
```java
//SecurityFilterChain 구성
@Autowired
SecurityPassUtils securityPassUtils

@Bean
protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    String[] permitAllUrls = securityPassUtils.getUrls(); // [ "/user/login.do" ]
        
    return http
    .authorizeHttpRequests(authorize -> authorize
        .antMatchers(permitAllUrls).permitAll()
        .anyRequest().authenticated()
    )
    .build();
}
```
```java
@SecurityPass
@SecurityPass(role="admin")
@SecurityPass(role="user")
@SecurityPass(role={"user","admin"})

String[] permitAllUrls = securityPassUtils.getUrls();
String[] permitAdminrls = securityPassUtils.getUrls("admin");
String[] permitUserUrls = securityPassUtils.getUrls("user");

```

의 방식으로 SecurityPass어노테이션이 붙은 메서드의 API를 쉽게 가져올 수 있습니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

![image](https://github.com/eGovFramework/egovframe-template-simple-backend/assets/30648191/8da74f6c-9f3b-47a0-b6da-73d7bfaf3c05)

#
# 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
