### PR TITLE
이전에 @RequestBody로 변경한 소스를 다시 @RequestParam으로 원상복구 시킴,

### DIFF
--- a/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
+++ b/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
@@ -8,7 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import egovframework.com.cmm.LoginVO;
@@ -104,7 +104,7 @@ public class EgovSiteManagerApiController {
 					ref = "#/components/schemas/passwordMap"),
 					style = ParameterStyle.FORM,
 					explode = Explode.TRUE
-					) @RequestBody Map<String, String> param, HttpServletRequest request, 
+					) @RequestParam Map<String, String> param, HttpServletRequest request, 
 			@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user) throws Exception {
 		ResultVO resultVO = new ResultVO();
 


### PR DESCRIPTION
## 수정 사유 Reason for modification
코드의 통일성을 위해서 이전에 @RequestBody로 변경한 소스를 다시 @RequestParam으로 원상 복구 시킴,
대신에, frontEnd인 react프로젝트 전송 값을 json데이터에서 formData로 변경 시킴
소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
EgovSiteManagerApiController.java의 updateAdminPassword 메서드에서 @RequestBody 를 @RequestParam으로 원상 복구 시킴.
## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷.
스웨거 화면에서 Parameters 항목이 Request body 에서 pram object 로 변경 됨.
![image](https://github.com/user-attachments/assets/94afa68d-2f33-44be-b6cf-c52cfa2018d1)

