### PR TITLE
Jwt 관련 버그 수정 및 리팩터링

### DIFF
--- a/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
+++ b/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
@@ -46,6 +46,29 @@ public class EgovJwtTokenUtil implements Serializable{
 		return claims.get(type).toString();
 	}
 
+	public Claims getClaimFromToken(String token) {
+		final Claims claims = getAllClaimsFromToken(token);
+		return claims;
+	}
+
+	//for retrieveing any information from token we will need the secret key
+	public Claims getAllClaimsFromToken(String token) {
+		log.debug("===>>> secret = "+SECRET_KEY);
+		return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody();
+	}
+
+	//generate token for user
+    public String generateToken(LoginVO loginVO) {
+        return doGenerateToken(loginVO, "Authorization");
+    }
+
+	//while creating the token -
+	//1. Define  claims of the token, like Issuer, Expiration, Subject, and the ID
+	//2. Sign the JWT using the HS512 algorithm and secret key.
+	//3. According to JWS Compact Serialization(https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#section-3.1)
+	//   compaction of the JWT to a URL-safe string
+	private String doGenerateToken(LoginVO loginVO, String subject) {
+		
         Map<String, Object> claims = new HashMap<>();
         claims.put("id", loginVO.getId() );
         claims.put("name", loginVO.getName() );
@@ -81,10 +104,4 @@ public class EgovJwtTokenUtil implements Serializable{
 
 		return loginVO;
 	}
-
-	// generate token for user
-	public String generateToken(LoginVO loginVO) {
-		return doGenerateToken(loginVO, "Authorization");
-	}
-
 }

--- a/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
+++ b/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
@@ -5,6 +5,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import org.springframework.stereotype.Component;
 
 import egovframework.com.cmm.LoginVO;
@@ -57,5 +61,30 @@ public class EgovJwtTokenUtil implements Serializable{
             .signWith(SignatureAlgorithm.HS512, SECRET_KEY).compact();
     }
 
+	public LoginVO getLoginVOFromToken(String token) throws InvalidJwtException{
+		LoginVO loginVO = new LoginVO();
+
+        try {
+		    loginVO.setId(getUserIdFromToken(token));
+			loginVO.setName(getInfoFromToken("name", token));
+			loginVO.setUserSe(getUserSeFromToken(token));
+			loginVO.setOrgnztId(getInfoFromToken("orgnztId", token));
+			loginVO.setUniqId(getInfoFromToken("uniqId", token));
+            loginVO.setGroupNm(getInfoFromToken("groupNm", token));
+
+            if(loginVO.getId() == null) throw new InvalidJwtException("Missing id in token");
+        } catch (IllegalArgumentException | ExpiredJwtException |
+                 MalformedJwtException | UnsupportedJwtException |
+                 SignatureException e) {
+            throw new InvalidJwtException("Unable to verify JWT Token: " + e.getMessage());
+        }
+
+		return loginVO;
+	}
+
+	// generate token for user
+	public String generateToken(LoginVO loginVO) {
+		return doGenerateToken(loginVO, "Authorization");
+	}
 
 }

--- a/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
+++ b/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
@@ -24,42 +24,23 @@ public class EgovJwtTokenUtil implements Serializable{
 	public static final long JWT_TOKEN_VALIDITY = (long) ((1 * 60 * 60) / 60) * 60; //토큰의 유효시간 설정, 기본 60분
 	
 	public static final String SECRET_KEY = EgovProperties.getProperty("Globals.jwt.secret");
-	
-	//retrieve username from jwt token
-    public String getUserIdFromToken(String token) {
-        Claims claims = getClaimFromToken(token);
-        return claims.get("id").toString();
-    }
-    public String getUserSeFromToken(String token) {
-        Claims claims = getClaimFromToken(token);
-        return claims.get("userSe").toString();
-    }
-    public String getInfoFromToken(String type, String token) {
-        Claims claims = getClaimFromToken(token);
-        return claims.get(type).toString();
-    }
-    public Claims getClaimFromToken(String token) {
-        final Claims claims = getAllClaimsFromToken(token);
-        return claims;
-    }
-	
-    //for retrieveing any information from token we will need the secret key
-    public Claims getAllClaimsFromToken(String token) {
-    	log.debug("===>>> secret = "+SECRET_KEY);
-        return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody();
-    }
+  
+	// retrieve username from jwt token
+	public String getUserIdFromToken(String token) {
+		return getInfoFromToken("id", token);
+	}
 
-    //generate token for user
-    public String generateToken(LoginVO loginVO) {
-        return doGenerateToken(loginVO, "Authorization");
-    }
+	public String getUserSeFromToken(String token) {
+		return getInfoFromToken("userSe", token);
+	}
 
-	//while creating the token -
-	//1. Define  claims of the token, like Issuer, Expiration, Subject, and the ID
-	//2. Sign the JWT using the HS512 algorithm and secret key.
-	//3. According to JWS Compact Serialization(https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#section-3.1)
-	//   compaction of the JWT to a URL-safe string
-    private String doGenerateToken(LoginVO loginVO, String subject) {
+	public String getInfoFromToken(String type, String token) {
+		Claims claims = getClaimFromToken(token);
+		Object info = claims.get(type);
+
+		if(info == null) return null;
+		return claims.get(type).toString();
+	}
 
         Map<String, Object> claims = new HashMap<>();
         claims.put("id", loginVO.getId() );

--- a/src/main/java/egovframework/com/jwt/InvalidJwtException.java
+++ b/src/main/java/egovframework/com/jwt/InvalidJwtException.java
@@ -1,0 +1,12 @@
+package egovframework.com.jwt;
+
+public class InvalidJwtException extends RuntimeException {
+    public InvalidJwtException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidJwtException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/egovframework/com/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/egovframework/com/jwt/JwtAuthenticationFilter.java
@@ -50,16 +50,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // step 2. 토큰에 내용이 있는지 확인해서 id값을 가져옴
         // Exception 핸들링 추가처리 (토큰 유효성, 토큰 변조 여부, 토큰 만료여부)
         // 내부적으로 parse하는 과정에서 해당 여부들이 검증됨
-        String id = null;
 
         try {
 
-            id = jwtTokenUtil.getUserIdFromToken(jwtToken);
-            if (id == null) {
-                logger.debug("jwtToken not validate");
-                verificationFlag =  false;
-            }
-            logger.debug("===>>> id = " + id);
         } catch (IllegalArgumentException | ExpiredJwtException | MalformedJwtException | UnsupportedJwtException | SignatureException e) {
             logger.debug("Unable to verify JWT Token: " + e.getMessage());
             verificationFlag = false;

--- a/src/main/java/egovframework/com/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/egovframework/com/jwt/JwtAuthenticationFilter.java
@@ -1,13 +1,7 @@
 package egovframework.com.jwt;
 
-import java.io.IOException;
-import java.util.Arrays;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import egovframework.com.cmm.LoginVO;
+import egovframework.let.utl.fcc.service.EgovStringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -15,12 +9,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import egovframework.com.cmm.LoginVO;
-import egovframework.let.utl.fcc.service.EgovStringUtil;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * fileName       : JwtAuthenticationFilter
@@ -41,7 +35,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override //로그인 이후 HttpServletRequest 요청할 때마다 실행(스프링의 AOP기능)
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
             throws IOException, ServletException {
-        boolean verificationFlag = true;
 
         // step 1. request header에서 토큰을 가져온다.
         String jwtToken = EgovStringUtil.isNullToString(req.getHeader(HEADER_STRING));
@@ -50,43 +43,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // step 2. 토큰에 내용이 있는지 확인해서 id값을 가져옴
         // Exception 핸들링 추가처리 (토큰 유효성, 토큰 변조 여부, 토큰 만료여부)
         // 내부적으로 parse하는 과정에서 해당 여부들이 검증됨
-
         try {
-
-        } catch (IllegalArgumentException | ExpiredJwtException | MalformedJwtException | UnsupportedJwtException | SignatureException e) {
-            logger.debug("Unable to verify JWT Token: " + e.getMessage());
-            verificationFlag = false;
-        }
-
-        LoginVO loginVO = new LoginVO();
-        if( verificationFlag ){
+            LoginVO loginVO = jwtTokenUtil.getLoginVOFromToken(jwtToken);
+            logger.debug("===>>> id = " + loginVO.getId());
             logger.debug("jwtToken validated");
-            loginVO.setId(id);
-            loginVO.setUserSe( jwtTokenUtil.getUserSeFromToken(jwtToken) );
-            loginVO.setUniqId( jwtTokenUtil.getInfoFromToken("uniqId",jwtToken) );
-            loginVO.setOrgnztId( jwtTokenUtil.getInfoFromToken("orgnztId",jwtToken) );
-            loginVO.setName( jwtTokenUtil.getInfoFromToken("name",jwtToken) );
-            loginVO.setGroupNm(jwtTokenUtil.getInfoFromToken("groupNm", jwtToken));//토큰에서 가져온 스프링시큐리티용 그룹명값 부여
             logger.debug("===>>> loginVO.getUserSe() = "+loginVO.getUserSe());
-            if(loginVO.getGroupNm().equals("ROLE_ADMIN")) { //스프링시큐리티 관리자 권한은 getGroupNm값으로 구분
-            	UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(loginVO, null,
-                        Arrays.asList(new SimpleGrantedAuthority("ROLE_ADMIN"))
-                );
-            	logger.debug("authentication1 ===>>> " + authentication);
-            	authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }else {
-            	UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(loginVO, null,
-                        Arrays.asList(new SimpleGrantedAuthority("ROLE_USER"))
-                );
-            	logger.debug("authentication2 ===>>> " + authentication);
-            	authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
-        }
 
+            String role = isAdmin(loginVO) ? "ROLE_ADMIN" : "ROLE_USER";
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    loginVO, null, Arrays.asList(new SimpleGrantedAuthority(role))
+            );
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            logger.debug("authentication ===>>> " + authentication);
+        } catch (InvalidJwtException e) {
+            logger.debug(e.getMessage());
+        }
 
         chain.doFilter(req, res);
+    }
 
+    private boolean isAdmin(LoginVO loginVO) {
+        return "ROLE_ADMIN".equals(loginVO.getGroupNm());
     }
 }

--- a/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
+++ b/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
@@ -1,0 +1,72 @@
+package egovframework.com.jwt;
+
+import egovframework.com.cmm.LoginVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class EgovJwtTokenUtilTest {
+
+    @Autowired
+    private EgovJwtTokenUtil jwtTokenUtil;
+
+    @DisplayName("올바른 토큰을 입력했을 때, LoginVO 객체를 반환한다.")
+    @Test
+    void testValidTokenReturnsLoginVO() {
+        // given
+        LoginVO loginVO = new LoginVO();
+        loginVO.setId("testUser");
+        loginVO.setName("Test User");
+        loginVO.setUserSe("USER");
+        loginVO.setOrgnztId("testOrg");
+        loginVO.setUniqId("testUniqId");
+        loginVO.setGroupNm("ROLE_USER");
+
+        String token = jwtTokenUtil.generateToken(loginVO);
+
+        // when
+        LoginVO result = jwtTokenUtil.getLoginVOFromToken(token);
+
+        // then
+        assertNotNull(result);
+        assertEquals("testUser", result.getId());
+        assertEquals("Test User", result.getName());
+        assertEquals("USER", result.getUserSe());
+        assertEquals("testOrg", result.getOrgnztId());
+        assertEquals("testUniqId", result.getUniqId());
+        assertEquals("ROLE_USER", result.getGroupNm());
+    }
+
+    @DisplayName("잘못된 토큰을 입력했을 때, InvalidJwtException 예외가 발생한다.")
+    @Test
+    void testInvalidTokenReturnsThrowException() {
+        // given
+        String token = "invalidToken";
+
+        // when
+        // then
+        assertThrows(InvalidJwtException.class, () -> {
+            jwtTokenUtil.getLoginVOFromToken(token);
+        });
+    }
+
+    @DisplayName("Id가 포함되지 않은 토큰을 입력했을 때, InvalidJwtException 예외가 발생한다.")
+    @Test
+    void testTokenWithoutIdReturnsThrowException() {
+        // given
+        LoginVO loginVO = new LoginVO();
+        String token = jwtTokenUtil.generateToken(loginVO);
+
+        // when
+        // then
+        assertThrows(InvalidJwtException.class, () -> {
+            jwtTokenUtil.getLoginVOFromToken(token);
+        });
+    }
+}

--- a/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
+++ b/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
@@ -7,14 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
 class EgovJwtTokenUtilTest {
 
-    @Autowired
-    private EgovJwtTokenUtil jwtTokenUtil;
+    private final EgovJwtTokenUtil jwtTokenUtil = new EgovJwtTokenUtil();
 
     @DisplayName("올바른 토큰을 입력했을 때, LoginVO 객체를 반환한다.")
     @Test

--- a/src/test/java/egovframework/com/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/egovframework/com/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,75 @@
+package egovframework.com.jwt;
+
+import egovframework.com.cmm.LoginVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.servlet.FilterChain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class JwtAuthenticationFilterTest {
+
+    @Autowired
+    private JwtAuthenticationFilter filter;
+
+    @MockBean
+    private EgovJwtTokenUtil jwtTokenUtil;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    public void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        filterChain = mock(FilterChain.class);
+        SecurityContextHolder.clearContext();
+    }
+
+    @DisplayName("유효한 토큰이 주어지면 인증 객체가 설정된다")
+    @Test
+    public void testValidTokenSetsAuthentication() throws Exception {
+        String fakeToken = "valid.jwt.token";
+
+        LoginVO loginVO = new LoginVO();
+        loginVO.setId("user1");
+        loginVO.setGroupNm("ROLE_ADMIN");
+
+        request.addHeader("Authorization", fakeToken);
+        when(jwtTokenUtil.getLoginVOFromToken(fakeToken)).thenReturn(loginVO);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals("user1", ((LoginVO) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId());
+    }
+
+    @DisplayName("유효하지 않은 토큰이 주어지면 인증 객체가 설정되지 않는다")
+    @Test
+    public void testInvalidTokenDoesNotSetAuthentication() throws Exception {
+        String invalidToken = "invalid.jwt.token";
+        request.addHeader("Authorization", invalidToken);
+
+        when(jwtTokenUtil.getLoginVOFromToken(invalidToken))
+                .thenThrow(new InvalidJwtException("Invalid token"));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}
+


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 1. EgovJwtTokenUtil :  NPE 발생 가능 로직 수정
- `claims.get("id") == null`인 경우 `toString()` 중 `NullPointerException`이 발생
- 따라서 필터의 `( id == null )` 분기에 도달할 수 없음

### 2. `JwtAuthenticationFilter` 로직 개선
- 로직은 유지하되 flag 제거해 가독성 개선
- JWT 파싱 중 발생한 예외의 상세 정보는 `JwtTokenUtil` 에서 추상화 처리
- 토큰 -> `LoginVO` 변환 로직 `JwtTokenUtil` 내부로 이동
- 어드민 확인 조건문 메서드 분리

### ~~3. `src/test/java/egovframework/study/jpa`~~

~~이전 PR에 학습용 코드가 포함된 것으로 보입니다.
테스트에서 문제가 발생하는 부분만 제거했으나, 확인 부탁드립니다.~~

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

![Image](https://github.com/user-attachments/assets/f4ef2c70-4cc4-4e84-b742-99712ab1dc3f)

![Image](https://github.com/user-attachments/assets/65fbd05b-b38c-49b2-8514-1717990a0254)