### PR TITLE
Refactor(bbs): selectBoardArticles 응답 구조 정리

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
@@ -7,8 +7,6 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import egovframework.let.cop.bbs.dto.response.BbsAttributeDetailResponseDTO;
-import egovframework.let.cop.bbs.dto.response.BbsAttributeListResponseDTO;
 import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import org.egovframe.rte.fdl.cryptography.EgovCryptoService;
 import org.egovframe.rte.fdl.property.EgovPropertyService;

--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
@@ -7,6 +7,9 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import egovframework.let.cop.bbs.dto.response.BbsAttributeDetailResponseDTO;
+import egovframework.let.cop.bbs.dto.response.BbsAttributeListResponseDTO;
+import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import org.egovframe.rte.fdl.cryptography.EgovCryptoService;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
@@ -152,34 +155,23 @@ public class EgovBBSManageApiController {
 			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
 	})
 	@GetMapping(value = "/board")
-	public ResultVO selectBoardArticles(@ModelAttribute BbsSearchRequestDTO boardMasterSearchVO, 
-			@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user)
+	public IntermediateResultVO<BbsManageListResponseDTO> selectBoardArticles(@ModelAttribute BbsSearchRequestDTO bbsSearchRequestDTO,
+																				 @Parameter(hidden = true) @AuthenticationPrincipal LoginVO user)
 		throws Exception {
-		BbsDetailResponse response = bbsAttrbService.selectBBSMasterInf(boardMasterSearchVO.getBbsId(), user.getUniqId(), BbsDetailRequestType.DETAIL);
+		BbsDetailResponse attributeDetailResponse = bbsAttrbService.selectBBSMasterInf(bbsSearchRequestDTO.getBbsId(), user.getUniqId(), BbsDetailRequestType.DETAIL);
+
 		PaginationInfo paginationInfo = new PaginationInfo();
-		paginationInfo.setCurrentPageNo(boardMasterSearchVO.getPageIndex());
+		paginationInfo.setCurrentPageNo(bbsSearchRequestDTO.getPageIndex());
 		paginationInfo.setRecordCountPerPage(propertyService.getInt("Globals.pageUnit"));
 		paginationInfo.setPageSize(propertyService.getInt("Globals.pageSize"));
-		
-		BoardVO boardVO = new BoardVO();
-		boardVO.setPageIndex(boardMasterSearchVO.getPageIndex());
-		boardVO.setBbsId(boardMasterSearchVO.getBbsId()); 
-		boardVO.setSearchCnd(boardMasterSearchVO.getSearchCnd());
-		boardVO.setSearchWrd(boardMasterSearchVO.getSearchWrd());
-		
-		boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-		boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
-		boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-		Map<String, Object> resultMap = bbsMngService.selectBoardArticles(boardVO, "");
-		int totCnt = Integer.parseInt((String)resultMap.get("resultCnt"));
-		paginationInfo.setTotalRecordCount(totCnt);
-		resultMap.put("boardVO", boardVO);
-		resultMap.put("brdMstrVO", response);
-		resultMap.put("paginationInfo", paginationInfo);
-		resultMap.put("user", user);
- 
-		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
+		BbsManageListResponseDTO response = bbsMngService.selectBoardArticles(bbsSearchRequestDTO, paginationInfo, "");
+		paginationInfo.setTotalRecordCount(response.getResultCnt());
+		response.setPaginationInfo(paginationInfo);
+		response.setUser(user);
+		response.setBrdMstrVO(attributeDetailResponse);
+
+		return IntermediateResultVO.success(response);
 	}
 
 	/**

--- a/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageDetailResponseDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageDetailResponseDTO.java
@@ -1,6 +1,5 @@
 package egovframework.let.cop.bbs.dto.response;
 
-import egovframework.let.cop.bbs.domain.model.BoardMasterVO;
 import egovframework.let.cop.bbs.domain.model.BoardVO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -23,7 +22,6 @@ import lombok.experimental.SuperBuilder;
  *
  * </pre>
  */
-
 @Getter
 @SuperBuilder
 @Schema(description = "게시물 정보 응답 DTO")

--- a/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageDetailResponseDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageDetailResponseDTO.java
@@ -1,0 +1,72 @@
+package egovframework.let.cop.bbs.dto.response;
+
+import egovframework.let.cop.bbs.domain.model.BoardMasterVO;
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * 게시물 정보를 반환하는 응답 DTO 클래스 입니다.
+ *
+ * @author 김재섭(nirsa)
+ * @since 2025.08.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일          수정자         수정내용
+ *   ----------    ------------     -------------------
+ *   2025.08.10    김재섭(nirsa)      최초 생성
+ *
+ * </pre>
+ */
+
+@Getter
+@SuperBuilder
+@Schema(description = "게시물 정보 응답 DTO")
+public class BbsManageDetailResponseDTO {
+    @Schema(description = "게시판 아이디", example="BBSMSTR_AAAAAAAAAAAA")
+    private String bbsId;
+
+    @Schema(description = "게시물 아이디", example="1")
+    private long nttId;
+
+    @Schema(description = "게시물 제목", example="게시물 제목입니다.")
+    private String nttSj;
+
+    @Schema(description = "조회수", example="0")
+    private int inqireCo;
+
+    @Schema(description = "답장위치", example="0")
+    private String replyLc;
+
+    @Schema(description = "사용플래그", example="Y")
+    private String bbsUseFlag;
+
+    @Schema(description = "최초 등록자명", example="관리자")
+    private String frstRegisterNm;
+
+    @Schema(description = "최초등록시점", example="2025-08-10")
+    private String frstRegisterPnttm;
+
+    /**
+     *  BoardVO vo → BbsManageDetailResponseDTO 변환 메서드 입니다.
+     * @param BoardVO
+     * @return BbsManageDetailResponseDTO
+     */
+    public static BbsManageDetailResponseDTO from(BoardVO vo) {
+        return BbsManageDetailResponseDTO.builder()
+                .bbsId(vo.getBbsId())
+                .nttId(vo.getNttId())
+                .nttSj(vo.getNttSj())
+                .inqireCo(vo.getInqireCo())
+                .replyLc(vo.getReplyLc())
+                .bbsUseFlag(vo.getUseAt())
+                .frstRegisterNm(vo.getFrstRegisterNm())
+                .frstRegisterPnttm(vo.getFrstRegisterPnttm())
+                .build();
+    }
+}

--- a/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageListResponseDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageListResponseDTO.java
@@ -1,0 +1,45 @@
+package egovframework.let.cop.bbs.dto.response;
+
+import egovframework.com.cmm.LoginVO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
+
+import java.util.List;
+
+/**
+ * BbsManage 게시판 리스트를 반환하는 응답 DTO 클래스 입니다.
+ *
+ * @author 김재섭(nirsa)
+ * @since 2025.08.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일          수정자         수정내용
+ *   ----------    ------------     -------------------
+ *   2025.08.10    김재섭(nirsa)      최초 생성
+ *
+ * </pre>
+ */
+
+@Getter
+@Builder
+@Schema(description = "BBsManage 게시판 리스트 조회 응답 DTO")
+public class BbsManageListResponseDTO {
+    private List<BbsManageDetailResponseDTO> resultList;
+    private int resultCnt;
+
+    @Setter
+    private BbsDetailResponse brdMstrVO;
+
+    @Setter
+    private PaginationInfo paginationInfo;
+
+    @Setter
+    private LoginVO user;
+}

--- a/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageListResponseDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageListResponseDTO.java
@@ -34,6 +34,10 @@ public class BbsManageListResponseDTO {
     private List<BbsManageDetailResponseDTO> resultList;
     private int resultCnt;
 
+    @Schema(
+            description = "게시판 마스터 상세",
+            implementation = BbsAttributeDetailResponseDTO.class
+    )
     @Setter
     private BbsDetailResponse brdMstrVO;
 

--- a/src/main/java/egovframework/let/cop/bbs/service/EgovBBSManageService.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/EgovBBSManageService.java
@@ -6,6 +6,9 @@ import egovframework.com.cmm.LoginVO;
 import egovframework.let.cop.bbs.domain.model.Board;
 import egovframework.let.cop.bbs.domain.model.BoardVO;
 import egovframework.let.cop.bbs.dto.request.BbsManageDeleteBoardRequestDTO;
+import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
+import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 
 /**
  * 게시물 관리를 위한 서비스 인터페이스  클래스
@@ -77,11 +80,12 @@ public interface EgovBBSManageService {
 	 * 조건에 맞는 게시물 목록을 조회 한다.
 	 * @return
 	 * 
-	 * @param boardVO
+	 * @param bbsSearchRequestDTO
+	 * @param paginationInfo
 	 * @param attrbFlag
 	 * @exception Exception Exception
 	 */
-	public Map<String, Object> selectBoardArticles(BoardVO boardVO, String attrbFlag)
+	public BbsManageListResponseDTO selectBoardArticles(BbsSearchRequestDTO bbsSearchRequestDTO, PaginationInfo paginationInfo, String attrbFlag)
 	  throws Exception;
 
 	/**

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
@@ -5,8 +5,15 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
+import egovframework.let.cop.bbs.dto.response.BbsAttributeDetailResponseDTO;
+import egovframework.let.cop.bbs.dto.response.BbsAttributeListResponseDTO;
+import egovframework.let.cop.bbs.dto.response.BbsManageDetailResponseDTO;
+import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.stereotype.Service;
 
 import egovframework.com.cmm.LoginVO;
@@ -113,7 +120,17 @@ public class EgovBBSManageServiceImpl extends EgovAbstractServiceImpl implements
 	 * @see egovframework.let.cop.bbs.brd.service.EgovBBSManageService#selectBoardArticles(egovframework.let.cop.bbs.domain.model.brd.service.BoardVO)
 	 */
 	@Override
-	public Map<String, Object> selectBoardArticles(BoardVO boardVO, String attrbFlag) throws Exception {
+	public BbsManageListResponseDTO selectBoardArticles(BbsSearchRequestDTO bbsSearchRequestDTO, PaginationInfo paginationInfo, String attrbFlag) throws Exception {
+		BoardVO boardVO = new BoardVO();
+		boardVO.setPageIndex(bbsSearchRequestDTO.getPageIndex());
+		boardVO.setBbsId(bbsSearchRequestDTO.getBbsId());
+		boardVO.setSearchCnd(bbsSearchRequestDTO.getSearchCnd());
+		boardVO.setSearchWrd(bbsSearchRequestDTO.getSearchWrd());
+
+		boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+		boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
+		boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
 		List<BoardVO> list = bbsMngDAO.selectBoardArticleList(boardVO);
 		List<BoardVO> result = new ArrayList<BoardVO>();
 		if ("BBSA01".equals(attrbFlag)) {
@@ -140,12 +157,14 @@ public class EgovBBSManageServiceImpl extends EgovAbstractServiceImpl implements
 
 		int cnt = bbsMngDAO.selectBoardArticleListCnt(boardVO);
 
-		Map<String, Object> map = new HashMap<String, Object>();
+		List<BbsManageDetailResponseDTO> dtoList = result.stream()
+				.map(BbsManageDetailResponseDTO::from)
+				.collect(Collectors.toList());
 
-		map.put("resultList", result);
-		map.put("resultCnt", Integer.toString(cnt));
-
-		return map;
+		return BbsManageListResponseDTO.builder()
+				.resultList(dtoList)
+				.resultCnt(cnt)
+				.build();
 	}
 
 	/**

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
-import egovframework.let.cop.bbs.dto.response.BbsAttributeDetailResponseDTO;
-import egovframework.let.cop.bbs.dto.response.BbsAttributeListResponseDTO;
 import egovframework.let.cop.bbs.dto.response.BbsManageDetailResponseDTO;
 import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;

--- a/src/main/java/egovframework/let/main/web/EgovMainApiController.java
+++ b/src/main/java/egovframework/let/main/web/EgovMainApiController.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
+import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,27 +71,21 @@ public class EgovMainApiController {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 
 		// 공지사항 메인 컨텐츠 조회 시작 ---------------------------------
-		BoardVO boardVO = new BoardVO();
-		boardVO.setPageUnit(5);
-		boardVO.setPageSize(10);
-		boardVO.setBbsId("BBSMSTR_AAAAAAAAAAAA");
-
 		PaginationInfo paginationInfo = new PaginationInfo();
 
-		paginationInfo.setCurrentPageNo(boardVO.getPageIndex());
-		paginationInfo.setRecordCountPerPage(boardVO.getPageUnit());
-		paginationInfo.setPageSize(boardVO.getPageSize());
+		paginationInfo.setCurrentPageNo(1);
+		paginationInfo.setRecordCountPerPage(5);
+		paginationInfo.setPageSize(10);
 
-		boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-		boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
-		boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+		BbsSearchRequestDTO bbsSearchRequestDTO = new BbsSearchRequestDTO();
+		bbsSearchRequestDTO.setBbsId("BBSMSTR_AAAAAAAAAAAA");
 
-		Map<String, Object> map = bbsMngService.selectBoardArticles(boardVO, "BBSA02");
-		resultMap.put("notiList", map.get("resultList"));
+		BbsManageListResponseDTO notiList = bbsMngService.selectBoardArticles(bbsSearchRequestDTO, paginationInfo,"BBSA02");
+		resultMap.put("notiList", notiList.getResultList());
 
-		boardVO.setBbsId("BBSMSTR_BBBBBBBBBBBB");
-		map = bbsMngService.selectBoardArticles(boardVO, "BBSA02");
-		resultMap.put("galList", map.get("resultList"));
+		bbsSearchRequestDTO.setBbsId("BBSMSTR_BBBBBBBBBBBB");
+		BbsManageListResponseDTO galList = bbsMngService.selectBoardArticles(bbsSearchRequestDTO, paginationInfo,"BBSA02");
+		resultMap.put("galList", galList.getResultList());
 
 		resultVO.setResult(resultMap);
 		resultVO.setResultCode(ResponseCode.SUCCESS.getCode());


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
### 1. Refactor(bbs): selectBoardArticles 응답 구조 정리
- 요청 객체 네이밍 일관성 적용: boardMasterSearchVO → bbsSearchRequestDTO
- 도메인 객체(BoardVO) 생성을 서비스 계층으로 이동
- 응답 객체 ManageDetail, ManageList DTO 생성 및 적용
- bbsMngService.selectBoardArticles 변경에 맞춰 EgovMainApiController 수정 (임시 검색 요청 DTO 사용)

### 2. Chore(bbs): 사용되지 않는 import 제거

### 3. Fix(bbs): 스웨거에서 brdMstrVO 필드 스키마 미출력 문제 해결
- BbsManageListResponseDTO 클래스의 brdMstrVO 필드에 @Schema(implementation = BbsAttributeDetailResponseDTO.class) 추가하여 Swagger 문서에서 자식 DTO 구조 출력


## JUnit 테스트 JUnit tests
- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 변경 전
<img width="1409" height="398" alt="image" src="https://github.com/user-attachments/assets/693730fb-2be1-4324-8108-c92ed24d8f44" />

### 변경 후
<img width="1410" height="656" alt="image" src="https://github.com/user-attachments/assets/efaea9a4-eb08-48b6-aa34-36cae6c332e8" />

<img width="1376" height="590" alt="image" src="https://github.com/user-attachments/assets/124d0cfd-8275-4770-b658-a9f580ba2830" />

<img width="1378" height="607" alt="image" src="https://github.com/user-attachments/assets/8a4c9293-d4f5-4e8f-b94d-f13ff822a003" />


