### PR TITLE
Fix(utl): EgovDateUtil 날짜 파싱 예외 처리 버그 수정 및 로깅 개선

### DIFF
--- a/src/main/java/egovframework/let/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovDateUtil.java
@@ -243,6 +243,7 @@ public class EgovDateUtil {
 			else
 				return false;
 		} catch (ParseException e) {
+			log.warn("Invalid date provided: year={}, month={}, day={}", year, month, day);
 			return false;
 		}
 	}
@@ -278,7 +279,8 @@ public class EgovDateUtil {
 			}
 			simpledateformat = new SimpleDateFormat(_toDateFormat, Locale.getDefault());
 		} catch (ParseException exception) {
-			log.debug("{}", exception);
+			log.error("Failed to parse date string: {}", strSource, exception);
+			return "";
 		}
 		if (simpledateformat.format(date) != null) {
 			return simpledateformat.format(date);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

1. checkDate 메소드는 날짜 파싱(parsing)에 실패했을 때 ParseException을 받으면, 아무런 기록도 남기지 않고 그냥 false만 반환합니다.
이렇게 되면 어떤 잘못된 값 때문에 실패했는지 추적하기가 매우 어렵습니다.
catch 블록에 log.warn()을 추가하여 어떤 값으로 인해 오류가 발생했는지 로그를 남기도록 합니다.

2. convertDate 메소드는 날짜 파싱에 실패하면 log.debug()로 로그만 남기고 계속 진행합니다. 이 경우 date 변수는 null이 되고, 바로
 아래 simpledateformat.format(date) 라인에서 NullPointerException이 발생하여 프로그램이 비정상적으로 종료될 수 있습니다.
파싱 실패 시 log.error()로 로그 레벨을 올리고, NullPointerException을 유발하는 코드에 도달하기 전에
  빈 문자열("")을 반환하도록 변경합니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
