### PR TITLE
common-lang3 보안취약점(통제되지 않은 재귀 취약점) 처리

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
 		<dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.18.0</version>
         </dependency>
 
 		<dependency>


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

보안취약점 개선

아파치 커먼즈 랭의 통제되지 않은 재귀 취약점. 이 문제는 Apache Commons Lang에 영향을 미칩니다: commons-lang:commons-lang 2.0에서 2.6까지, 그리고 org.apache.commons:commons-lang3 3.0부터 3.18.0 이전. 메서드 ClassUtils.getClass(...)는 매우 긴 입력에 StackOverflowError를 던질 수 있습니다. 오류는 일반적으로 애플리케이션과 라이브러리에서 처리되지 않기 때문에 StackOverflowError로 인해 애플리케이션이 중지될 수 있습니다. 사용자는 문제를 해결하는 버전 3.18.0으로 업그레이드하는 것이 좋습니다.

## 수정된 소스 내용 Modified source
pom.xml 아래 내용 수정
commons-lang3 라이브러리 버전 변경
3.14.0 -> 3.18.0

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

<img width="1579" height="1350" alt="image" src="https://github.com/user-attachments/assets/1a12f2d8-a9f8-4783-8798-4237b06b1963" />

