### PR TITLE
refactor(bbsManage-updateBoardArticle) : JWT 유틸 분리, 파일 업로드 서비스 이전, 스웨거 호환

### DIFF
--- a/src/main/java/egovframework/com/cmm/util/XssUtil.java
+++ b/src/main/java/egovframework/com/cmm/util/XssUtil.java
@@ -1,0 +1,57 @@
+package egovframework.com.cmm.util;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * XSS(크로스 사이트 스크립팅) 방지를 위한 유틸리티 클래스
+ *
+ * <p>
+ * 게시물 입력 값에서 스크립트, 오브젝트, 애플릿, 임베드, 폼 태그 등을
+ * HTML 이스케이프 처리하여 보안 취약점을 예방한다.
+ * </p>
+ *
+ * @author 김재섭(nirsa)
+ * @since 2025.09.03
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일        수정자             수정내용
+ *  ----------    ----------        ---------------------------
+ *  2025.09.03    김재섭(nirsa)      구조 개선하며 unscript 메서드를 해당 클래스로 이동
+ * </pre>
+ */
+@Component
+public class XssUtil {
+    /**
+     * XSS 방지 처리.
+     *
+     * @param data
+     * @return
+     */
+    public String unscript(String data) {
+        if (data == null || data.trim().equals("")) {
+            return "";
+        }
+
+        String ret = data;
+
+        ret = ret.replaceAll("<(S|s)(C|c)(R|r)(I|i)(P|p)(T|t)", "&lt;script");
+        ret = ret.replaceAll("</(S|s)(C|c)(R|r)(I|i)(P|p)(T|t)", "&lt;/script");
+
+        ret = ret.replaceAll("<(O|o)(B|b)(J|j)(E|e)(C|c)(T|t)", "&lt;object");
+        ret = ret.replaceAll("</(O|o)(B|b)(J|j)(E|e)(C|c)(T|t)", "&lt;/object");
+
+        ret = ret.replaceAll("<(A|a)(P|p)(P|p)(L|l)(E|e)(T|t)", "&lt;applet");
+        ret = ret.replaceAll("</(A|a)(P|p)(P|p)(L|l)(E|e)(T|t)", "&lt;/applet");
+
+        ret = ret.replaceAll("<(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;embed");
+        ret = ret.replaceAll("</(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;embed");
+
+        ret = ret.replaceAll("<(F|f)(O|o)(R|r)(M|m)", "&lt;form");
+        ret = ret.replaceAll("</(F|f)(O|o)(R|r)(M|m)", "&lt;form");
+
+        return ret;
+    }
+}

--- a/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
+++ b/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import egovframework.let.utl.fcc.service.EgovStringUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
@@ -18,11 +19,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.servlet.http.HttpServletRequest;
+
 //security 관련 제외한 jwt util 클래스
 @Slf4j
 @Component
 public class EgovJwtTokenUtil implements Serializable{
-
+	public static final String HEADER_STRING = "Authorization";
 	private static final long serialVersionUID = -5180902194184255251L;
 	//public static final long JWT_TOKEN_VALIDITY = 24 * 60 * 60; //하루
 	public static final long JWT_TOKEN_VALIDITY = (long) ((1 * 60 * 60) / 60) * 60; //토큰의 유효시간 설정, 기본 60분
@@ -58,7 +61,7 @@ public class EgovJwtTokenUtil implements Serializable{
 
 	//generate token for user
     public String generateToken(LoginVO loginVO) {
-        return doGenerateToken(loginVO, "Authorization");
+        return doGenerateToken(loginVO, HEADER_STRING);
     }
 
 	//while creating the token -
@@ -102,5 +105,29 @@ public class EgovJwtTokenUtil implements Serializable{
         }
 
 		return loginVO;
+	}
+
+	/**
+	 * JWT 토큰에서 사용자 정보를 추출하여 LoginVO 객체를 반환한다.
+	 *
+	 * <p>
+	 * Authorization 헤더에 포함된 JWT 토큰에서 사용자 고유 식별자(uniqId)를 추출하여,
+	 * 인증된 사용자 정보를 LoginVO 형태로 반환한다.
+	 * 고정 값 : USRCNFRM_00000000000
+	 * </p>
+	 *
+	 * @param request HttpServletRequest 객체 (Authorization 헤더 포함)
+	 * @return LoginVO 사용자 고유 ID가 설정된 로그인 정보 객체
+	 */
+    public LoginVO extractUserFromJwt(HttpServletRequest request) {
+		String jwtToken = EgovStringUtil.isNullToString(request.getHeader(HEADER_STRING));
+		String uniqId = getInfoFromToken("uniqId", jwtToken);
+		String userNm = getInfoFromToken("name",jwtToken);
+
+		LoginVO user = new LoginVO();
+		user.setUniqId(uniqId);
+		user.setName(userNm);
+
+		return user;
 	}
 }

--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
@@ -240,9 +240,48 @@ public class EgovBBSManageApiController {
 			tags = {"EgovBBSManageApiController"}
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "수정 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+			@ApiResponse(
+					responseCode = "200",
+					description = "수정 성공",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									name = "200 응답 예시",
+									summary = "Forbidden",
+									value = "{\n" +
+											"  \"resultCode\": 200,\n" +
+											"  \"resultMessage\": \"성공했습니다.\"\n" +
+											"}"
+							)
+					)),
+			@ApiResponse(
+					responseCode = "403",
+					description = "인가된 사용자가 아님",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									name = "403 응답 예시",
+									summary = "Forbidden",
+									value = "{\n" +
+											"  \"resultCode\": 403,\n" +
+											"  \"resultMessage\": \"인가된 사용자가 아님\"\n" +
+											"}"
+							)
+					)),
+			@ApiResponse(
+					responseCode = "900",
+					description = "입력값 무결성 오류",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									name = "900 응답 예시",
+									summary = "Forbidden",
+									value = "{\n" +
+											"  \"resultCode\": 900,\n" +
+											"  \"resultMessage\": \"입력값 무결성 오류\"\n" +
+											"}"
+							)
+					)),
 	})
 	@PutMapping(value = "/board/{nttId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public IntermediateResultVO<Object> updateBoardArticle(

--- a/src/main/java/egovframework/let/cop/bbs/dto/request/BbsManageUpdateRequestDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/request/BbsManageUpdateRequestDTO.java
@@ -1,0 +1,84 @@
+package egovframework.let.cop.bbs.dto.request;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 게시물 수정 요청을 위한 DTO 클래스
+ * 게시물 정보를 수정할 때 사용되는 요청 데이터를 구조화한 객체입니다.
+ *
+ * @author 김재섭(nirsa)
+ * @since 2025.09.03
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일          수정자         수정내용
+ *   ----------    ------------     -------------------
+ *   2025.09.03    김재섭(nirsa)      최초 생성
+ *
+ * </pre>
+ */
+@Getter
+@Setter
+@Schema(description = "게시물 수정 요청")
+public class BbsManageUpdateRequestDTO {
+    @Schema(description = "게시판 아이디", example = "BBSMSTR_AAAAAAAAAAAA")
+    private String bbsId;
+
+    @Schema(description = "게시자 아이디", example = "USRCNFRM_00000000000")
+    private String ntcrId;
+
+    @Schema(description = "게시자명", example = "관리자")
+    private String ntcrNm;
+
+    @Schema(description = "게시물 아이디", example = "1")
+    private long nttId;
+
+    @Schema(description = "게시물 제목", example = "게시물 제목입니다.")
+    private String nttSj;
+
+    @Schema(description = "게시물 내용", example = "게시물 내용입니다.")
+    private String nttCn;
+
+    @Schema(description = "패스워드", example = "4/hNOJJJTB26aAcPzaEFoGQQ5eTP/cEzxFqbgzqHE30=")
+    private String password;
+
+    @Schema(description = "게시시작일(사용 여부 확인되지 않음)", example = "")
+    private String ntceBgnde;
+
+    @Schema(description = "게시종료일(사용 여부 확인되지 않음)", example = "")
+    private String ntceEndde;
+
+    @Schema(description = "최종수정자 아이디", example = "USRCNFRM_00000000000")
+    private String lastUpdusrId;
+
+    @Schema(description = "게시물 첨부파일 아이디(없을 경우 스페이스 20칸)", example = "FILE_000000000000001")
+    private String atchFileId;
+
+    /**
+     * BbsManageUpdateRequestDTO → BoardMaster 변환 메서드
+     *
+     * @return BoardMaster 도메인 객체
+     */
+    public BoardVO toBoardMaster(BbsManageUpdateRequestDTO bbsManageUpdateRequestDTO, LoginVO user) {
+        BoardVO vo = new BoardVO();
+        vo.setBbsId(bbsManageUpdateRequestDTO.getBbsId());
+        vo.setNtcrId(bbsManageUpdateRequestDTO.getNtcrId());
+        vo.setNtcrNm(user.getName());
+        vo.setNttId(bbsManageUpdateRequestDTO.getNttId());
+        vo.setNttSj(bbsManageUpdateRequestDTO.getNttSj());
+        vo.setNttCn(bbsManageUpdateRequestDTO.getNttCn());
+        vo.setPassword(bbsManageUpdateRequestDTO.getPassword());
+        vo.setNtceBgnde(bbsManageUpdateRequestDTO.getNtceBgnde());
+        vo.setNtceEndde(bbsManageUpdateRequestDTO.getNtceEndde());
+        vo.setLastUpdusrId(user.getUniqId());
+        vo.setAtchFileId(bbsManageUpdateRequestDTO.getAtchFileId());
+
+        return vo;
+    }
+}

--- a/src/main/java/egovframework/let/cop/bbs/service/EgovBBSManageService.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/EgovBBSManageService.java
@@ -1,5 +1,6 @@
 package egovframework.let.cop.bbs.service;
 
+import java.util.List;
 import java.util.Map;
 
 import egovframework.com.cmm.LoginVO;
@@ -7,11 +8,12 @@ import egovframework.let.cop.bbs.domain.model.Board;
 import egovframework.let.cop.bbs.domain.model.BoardVO;
 import egovframework.let.cop.bbs.dto.request.BbsManageDeleteBoardRequestDTO;
 import egovframework.let.cop.bbs.dto.request.BbsManageDetailBoardRequestDTO;
+import egovframework.let.cop.bbs.dto.request.BbsManageUpdateRequestDTO;
 import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
-import egovframework.let.cop.bbs.dto.response.BbsManageDetailItemResponseDTO;
 import egovframework.let.cop.bbs.dto.response.BbsManageDetailResponseDTO;
 import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 게시물 관리를 위한 서비스 인터페이스  클래스
@@ -104,10 +106,10 @@ public interface EgovBBSManageService {
 	/**
 	 * 게시물 한 건의 내용을 수정 한다.
 	 * 
-	 * @param Board
+	 * @param bbsManageUpdateRequestDTO
 	 * @exception Exception Exception
 	 */
-	public void updateBoardArticle(Board Board)
+	public void updateBoardArticle(BbsManageUpdateRequestDTO bbsManageUpdateRequestDTO, LoginVO user, List<MultipartFile> files)
 	  throws Exception;
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
###  **JWT 유틸 분리, 파일 업로드 서비스 이전, Swagger 호환 List<MultipartFile> 적용**
 - extractUserFromJwt(...) 메서드를 JwtTokenUtil로 이동하고 컨트롤러 사용부 수정
 - XssUtil 생성 및 컨트롤러에 빈 임시 주입(후속 리팩토링 시 제거 예정)
 - 첨부파일 업로드/파싱 로직을 컨트롤러 → 서비스 계층으로 이전
 - Swagger 지원을 위해 컨트롤러 시그니처 변경
   - `MultipartHttpServletRequest` → `List<MultipartFile>`
   - 프론트에서 다중 파일 키를 file_${i} → files로 요청하도록 로직 변경
     - https://github.com/eGovFramework/egovframe-template-simple-react/pull/87
   - 변경 영향으로 현재 insert는 파일 1개만 업로드되는 상태 (해당 PR 머지 후 다중 업로드 정상화 예정)
 - 요청 DTO와 비즈니스/도메인 객체 분리로 책임 명확화
 
## JUnit 테스트 JUnit tests
- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
### **적용 전**
<img width="1415" height="690" alt="image" src="https://github.com/user-attachments/assets/eeaf6d69-86f2-4063-9a4a-f0b423f525ae" />
<img width="1073" height="771" alt="image" src="https://github.com/user-attachments/assets/4a7e8175-e70b-4f1d-9ada-ad3e247ebadb" />

### **적용 후**
<img width="1277" height="875" alt="image" src="https://github.com/user-attachments/assets/3d68edc3-50b0-475e-8e59-3161c1055983" />
<img width="1141" height="898" alt="image" src="https://github.com/user-attachments/assets/0cdd59f2-184d-40a4-9d1e-3185e8c78ff4" />

<img width="1044" height="728" alt="image" src="https://github.com/user-attachments/assets/23e37c03-c52a-43cf-9dc6-6e67f2250feb" />
<img width="1031" height="790" alt="image" src="https://github.com/user-attachments/assets/9ef8fad1-d226-472b-943d-953c39baab62" />
