### PR TITLE
Refactor: Separate Swagger API documentation into interface

### DIFF
--- a/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApi.java
+++ b/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApi.java
@@ -46,6 +46,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  *
  *      </pre>
  */
+
 @Tag(name = "EgovMberManageApi", description = "회원 관리")
 public interface EgovMberManageApi {
 
@@ -57,7 +58,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "관리자단에서 회원 목록조회화면", description = "관리자단에서 회원에 대한 목록을 조회", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
@@ -76,7 +77,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "관리자단에서 회원 등록화면", description = "관리자단에서 회원등록화면에 필요한 값 생성", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
@@ -94,7 +95,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "관리자단에서 회원 등록처리", description = "관리자단에서 회원 등록처리", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "등록 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
@@ -112,7 +113,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "관리자단에서 회원정보 수정용 상세조회화면", description = "관리자단에서 회원정보 수정을 위해 회원정보를 상세조회", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
@@ -129,7 +130,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "관리자단에서 회원 수정처리", description = "관리자단에서 회원 수정처리", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "등록 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
@@ -147,7 +148,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "관리자단에서 회원 삭제처리", description = "관리자단에서 회원 삭제처리", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "삭제 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
@@ -164,7 +165,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "사용자단에서 회원정보 수정용 상세조회화면", description = "사용자단에서 회원정보 수정을 위해 회원정보를 상세조회", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
@@ -181,7 +182,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "사용자단에서 회원 수정처리", description = "사용자단에서 회원 수정처리", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "등록 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
@@ -199,7 +200,7 @@ public interface EgovMberManageApi {
 	 * @throws Exception
 	 */
 	@Operation(summary = "사용자단에서 회원 탈퇴처리", description = "사용자단에서 회원 탈퇴처리", security = {
-		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+		@SecurityRequirement(name = "Authorization") })
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "등록 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
@@ -216,7 +217,7 @@ public interface EgovMberManageApi {
 	 * @return resultVO
 	 * @throws Exception
 	 */
-	@Operation(summary = "사용자단에서 회원 등록처리", description = "사용자단에서 회원 등록처리", tags = { "EgovMberManageApiController" })
+	@Operation(summary = "사용자단에서 회원 등록처리", description = "사용자단에서 회원 등록처리")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "등록 성공"),
 		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
@@ -233,8 +234,7 @@ public interface EgovMberManageApi {
 	 * @return resultVO
 	 * @throws Exception
 	 */
-	@Operation(summary = "사용자단에서 회원 가입화면", description = "사용자단에서 회원가입화면에 필요한 값 생성", tags = {
-		"EgovMberManageApiController" })
+	@Operation(summary = "사용자단에서 회원 가입화면", description = "사용자단에서 회원가입화면에 필요한 값 생성")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 	})
@@ -248,8 +248,7 @@ public interface EgovMberManageApi {
 	 * @return resultVO
 	 * @throws Exception
 	 */
-	@Operation(summary = "사용자단에서 회원 약관확인", description = "사용자단에서 회원 약관확인에 필요한 값 생성", tags = {
-		"EgovMberManageApiController" })
+	@Operation(summary = "사용자단에서 회원 약관확인", description = "사용자단에서 회원 약관확인에 필요한 값 생성")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 	})
@@ -263,8 +262,7 @@ public interface EgovMberManageApi {
 	 * @return resultVO
 	 * @throws Exception
 	 */
-	@Operation(summary = "사용자아이디의 중복여부 체크처리", description = "사용자아이디의 중복여부 체크처리", tags = {
-		"EgovMberManageApiController" })
+	@Operation(summary = "사용자아이디의 중복여부 체크처리", description = "사용자아이디의 중복여부 체크처리")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")

--- a/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApi.java
+++ b/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApi.java
@@ -1,0 +1,274 @@
+package egovframework.let.uss.umt.web;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.ResultVO;
+import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
+import egovframework.let.uss.umt.service.MberManageVO;
+import egovframework.let.uss.umt.service.UserDefaultVO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+/**
+ * 회원관련 요청을 비지니스 클래스로 전달하고 처리된 결과를 해당 웹 화면으로 전달하는 Controller 에 대한 API 를 분리합니다.
+ *
+ * @author
+ * @since 2025.09.06
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.09.06  박준규		   최초 생성
+ *
+ *      </pre>
+ */
+@Tag(name = "EgovMberManageApi", description = "회원 관리")
+public interface EgovMberManageApi {
+
+	/**
+	 * 관리자단에서 회원목록을 조회한다. (paging)
+	 *
+	 * @param request
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "관리자단에서 회원 목록조회화면", description = "관리자단에서 회원에 대한 목록을 조회", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
+	})
+	@GetMapping(value = "/members")
+	ResultVO selectMberList(@ModelAttribute BbsSearchRequestDTO boardMasterSearchVO,
+		@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user) throws Exception;
+
+
+	/**
+	 * 관리자단에서 회원등록화면으로 이동한다.
+	 *
+	 * @param userSearchVO 검색조건정보
+	 * @param mberManageVO 회원초기화정보
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "관리자단에서 회원 등록화면", description = "관리자단에서 회원등록화면에 필요한 값 생성", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
+	})
+	@GetMapping("/members/insert")
+	ResultVO insertMberView(UserDefaultVO userSearchVO, MberManageVO mberManageVO) throws Exception;
+
+
+	/**
+	 * 관리자단에서 회원등록처리
+	 *
+	 * @param mberManageVO  회원등록정보
+	 * @param bindingResult 입력값검증용 bindingResult
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "관리자단에서 회원 등록처리", description = "관리자단에서 회원 등록처리", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "등록 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
+		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+	})
+	@PostMapping("/members/insert")
+	ResultVO insertMber(MberManageVO mberManageVO, BindingResult bindingResult) throws Exception;
+
+	/**
+	 * 관리자단에서 회원정보 수정을 위해 회원정보를 상세조회한다.
+	 *
+	 * @param uniqId       상세조회대상 회원아이디
+	 * @param userSearchVO 검색조건
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "관리자단에서 회원정보 수정용 상세조회화면", description = "관리자단에서 회원정보 수정을 위해 회원정보를 상세조회", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
+	})
+	@GetMapping("/members/update/{uniqId}")
+	ResultVO updateMberView(@PathVariable("uniqId") String uniqId, UserDefaultVO userSearchVO) throws Exception;
+
+	/**
+	 * 관리자단에서 회원수정 처리
+	 *
+	 * @param mberManageVO  회원수정정보
+	 * @param bindingResult 입력값검증용 bindingResult
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "관리자단에서 회원 수정처리", description = "관리자단에서 회원 수정처리", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "등록 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
+		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+	})
+	@PutMapping("/members/update")
+	ResultVO updateMber(@RequestBody MberManageVO mberManageVO, BindingResult bindingResult) throws Exception;
+
+	/**
+	 * 관리자단에서 회원정보삭제.
+	 *
+	 * @param checkedIdForDel 삭제대상 아이디 정보
+	 * @param userSearchVO    검색조건정보
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "관리자단에서 회원 삭제처리", description = "관리자단에서 회원 삭제처리", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "삭제 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
+		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+	})
+	@DeleteMapping("/members/delete/{uniqId}")
+	ResultVO deleteMber(@PathVariable("uniqId") String uniqId, UserDefaultVO userSearchVO) throws Exception;
+
+	/**
+	 * 사용자단에서 회원정보 수정을 위해 회원정보를 상세조회한다.
+	 *
+	 * @param user 인증된 사용자 정보
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자단에서 회원정보 수정용 상세조회화면", description = "사용자단에서 회원정보 수정을 위해 회원정보를 상세조회", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
+	})
+	@GetMapping("/mypage")
+	ResultVO selectMypageView(@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user) throws Exception;
+
+	/**
+	 * 사용자단에서 회원 수정처리
+	 *
+	 * @param mberManageVO  회원수정정보
+	 * @param bindingResult 입력값검증용 bindingResult
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자단에서 회원 수정처리", description = "사용자단에서 회원 수정처리", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "등록 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
+		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+	})
+	@PutMapping("/mypage/update")
+	ResultVO updateMypage(@RequestBody MberManageVO mberManageVO, BindingResult bindingResult) throws Exception;
+
+	/**
+	 * 사용자단에서 회원탈퇴 처리
+	 *
+	 * @param mberManageVO  회원수정정보
+	 * @param bindingResult 입력값검증용 bindingResult
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자단에서 회원 탈퇴처리", description = "사용자단에서 회원 탈퇴처리", security = {
+		@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "등록 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
+		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+	})
+	@PutMapping("/mypage/delete")
+	ResultVO deleteMypage(@RequestBody MberManageVO mberManageVO, BindingResult bindingResult,
+		HttpServletRequest request, HttpServletResponse response) throws Exception;
+
+	/**
+	 * 사용자단에서 회원가입신청등록처리.
+	 *
+	 * @param mberManageVO 회원가입신청정보
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자단에서 회원 등록처리", description = "사용자단에서 회원 등록처리", tags = { "EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "등록 성공"),
+		@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
+	})
+	@PostMapping("/etc/member_insert")
+	ResultVO sbscrbMber(MberManageVO mberManageVO, BindingResult bindingResult) throws Exception;
+
+	/**
+	 * 사용자단에서 회원가입신청(등록화면)으로 이동한다.
+	 *
+	 * @param userSearchVO 검색조건
+	 * @param mberManageVO 회원가입신청정보
+	 * @param commandMap   파라메터전달용 commandMap
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자단에서 회원 가입화면", description = "사용자단에서 회원가입화면에 필요한 값 생성", tags = {
+		"EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+	})
+	@GetMapping("/etc/member_insert")
+	public ResultVO sbscrbMberView(UserDefaultVO userSearchVO, MberManageVO mberManageVO,
+		@RequestParam Map<String, Object> commandMap) throws Exception;
+
+	/**
+	 * 회원 약관확인
+	 *
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자단에서 회원 약관확인", description = "사용자단에서 회원 약관확인에 필요한 값 생성", tags = {
+		"EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+	})
+	@GetMapping("/etc/member_agreement")
+	ResultVO sbscrbEntrprsMber() throws Exception;
+
+	/**
+	 * 사용자아이디의 중복여부를 체크하여 사용가능여부를 확인
+	 *
+	 * @param commandMap 파라메터전달용 commandMap
+	 * @return resultVO
+	 * @throws Exception
+	 */
+	@Operation(summary = "사용자아이디의 중복여부 체크처리", description = "사용자아이디의 중복여부 체크처리", tags = {
+		"EgovMberManageApiController" })
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
+	})
+	@GetMapping("/etc/member_checkid/{checkid}")
+	ResultVO checkIdDplct(@PathVariable("checkid") String checkId) throws Exception;
+}

--- a/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
+++ b/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
@@ -34,12 +34,7 @@ import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
 import egovframework.let.uss.umt.service.EgovMberManageService;
 import egovframework.let.uss.umt.service.MberManageVO;
 import egovframework.let.uss.umt.service.UserDefaultVO;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
+++ b/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
@@ -44,7 +44,7 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * 회원관련 요청을 비지니스 클래스로 전달하고 처리된 결과를 해당 웹 화면으로 전달하는 Controller를 정의한다
- * 
+ *
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10
  * @version 1.0
@@ -57,13 +57,13 @@ import lombok.RequiredArgsConstructor;
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
  *   2024.07.22  김일국          Boot 템플릿 커스터마이징버전 생성
+ *   2025.09.06  박준규		   Swagger Annotation 분리
  *
  *      </pre>
  */
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "EgovMberManageApiController", description = "회원 관리")
-public class EgovMberManageApiController {
+public class EgovMberManageApiController implements EgovMberManageApi {
 
 	private EgovJwtTokenUtil jwtTokenUtil;
 	public static final String HEADER_STRING = "Authorization";
@@ -74,24 +74,12 @@ public class EgovMberManageApiController {
 	private final DefaultBeanValidator beanValidator;
 	private final ResultVoHelper resultVoHelper;
 
-	/**
-	 * 관리자단에서 회원목록을 조회한다. (paging)
-	 * 
-	 * @param request
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "관리자단에서 회원 목록조회화면", description = "관리자단에서 회원에 대한 목록을 조회", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
-	})
+	@Override
 	@GetMapping(value = "/members")
 	public ResultVO selectMberList(
-			@ModelAttribute BbsSearchRequestDTO boardMasterSearchVO,
-			@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user)
-			throws Exception {
+		@ModelAttribute BbsSearchRequestDTO boardMasterSearchVO,
+		@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user)
+		throws Exception {
 
 		MberManageVO userSearchVO = new MberManageVO();
 
@@ -143,23 +131,10 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 관리자단에서 회원등록화면으로 이동한다.
-	 * 
-	 * @param userSearchVO 검색조건정보
-	 * @param mberManageVO 회원초기화정보
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "관리자단에서 회원 등록화면", description = "관리자단에서 회원등록화면에 필요한 값 생성", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
-	})
+	@Override
 	@GetMapping("/members/insert")
 	public ResultVO insertMberView(UserDefaultVO userSearchVO, MberManageVO mberManageVO)
-			throws Exception {
+		throws Exception {
 
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -179,21 +154,6 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 관리자단에서 회원등록처리
-	 * 
-	 * @param mberManageVO  회원등록정보
-	 * @param bindingResult 입력값검증용 bindingResult
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "관리자단에서 회원 등록처리", description = "관리자단에서 회원 등록처리", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "등록 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
-	})
 	@PostMapping("/members/insert")
 	public ResultVO insertMber(MberManageVO mberManageVO, BindingResult bindingResult) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -229,20 +189,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 관리자단에서 회원정보 수정을 위해 회원정보를 상세조회한다.
-	 * 
-	 * @param uniqId       상세조회대상 회원아이디
-	 * @param userSearchVO 검색조건
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "관리자단에서 회원정보 수정용 상세조회화면", description = "관리자단에서 회원정보 수정을 위해 회원정보를 상세조회", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
-	})
+	@Override
 	@GetMapping("/members/update/{uniqId}")
 	public ResultVO updateMberView(@PathVariable("uniqId") String uniqId, UserDefaultVO userSearchVO) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -271,21 +218,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 관리자단에서 회원수정 처리
-	 * 
-	 * @param mberManageVO  회원수정정보
-	 * @param bindingResult 입력값검증용 bindingResult
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "관리자단에서 회원 수정처리", description = "관리자단에서 회원 수정처리", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "등록 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
-	})
+	@Override
 	@PutMapping("/members/update")
 	public ResultVO updateMber(@RequestBody MberManageVO mberManageVO, BindingResult bindingResult) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -321,21 +254,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 관리자단에서 회원정보삭제.
-	 * 
-	 * @param checkedIdForDel 삭제대상 아이디 정보
-	 * @param userSearchVO    검색조건정보
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "관리자단에서 회원 삭제처리", description = "관리자단에서 회원 삭제처리", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "삭제 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
-	})
+	@Override
 	@DeleteMapping("/members/delete/{uniqId}")
 	public ResultVO deleteMber(@PathVariable("uniqId") String uniqId, UserDefaultVO userSearchVO) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -345,19 +264,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 사용자단에서 회원정보 수정을 위해 회원정보를 상세조회한다.
-	 * 
-	 * @param user 인증된 사용자 정보
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자단에서 회원정보 수정용 상세조회화면", description = "사용자단에서 회원정보 수정을 위해 회원정보를 상세조회", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
-	})
+	@Override
 	@GetMapping("/mypage")
 	public ResultVO selectMypageView(@Parameter(hidden = true) @AuthenticationPrincipal LoginVO user) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -391,21 +298,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 사용자단에서 회원 수정처리
-	 * 
-	 * @param mberManageVO  회원수정정보
-	 * @param bindingResult 입력값검증용 bindingResult
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자단에서 회원 수정처리", description = "사용자단에서 회원 수정처리", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "등록 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
-	})
+	@Override
 	@PutMapping("/mypage/update")
 	public ResultVO updateMypage(@RequestBody MberManageVO mberManageVO, BindingResult bindingResult) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -426,24 +319,10 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 사용자단에서 회원탈퇴 처리
-	 * 
-	 * @param mberManageVO  회원수정정보
-	 * @param bindingResult 입력값검증용 bindingResult
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자단에서 회원 탈퇴처리", description = "사용자단에서 회원 탈퇴처리", security = {
-			@SecurityRequirement(name = "Authorization") }, tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "등록 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
-	})
+	@Override
 	@PutMapping("/mypage/delete")
 	public ResultVO deleteMypage(@RequestBody MberManageVO mberManageVO, BindingResult bindingResult,
-			HttpServletRequest request, HttpServletResponse response) throws Exception {
+		HttpServletRequest request, HttpServletResponse response) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 
 		beanValidator.validate(mberManageVO, bindingResult);
@@ -461,18 +340,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 사용자단에서 회원가입신청등록처리.
-	 * 
-	 * @param mberManageVO 회원가입신청정보
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자단에서 회원 등록처리", description = "사용자단에서 회원 등록처리", tags = { "EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "등록 성공"),
-			@ApiResponse(responseCode = "900", description = "입력값 무결성 오류")
-	})
+	@Override
 	@PostMapping("/etc/member_insert")
 	public ResultVO sbscrbMber(MberManageVO mberManageVO, BindingResult bindingResult) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -493,23 +361,10 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 사용자단에서 회원가입신청(등록화면)으로 이동한다.
-	 * 
-	 * @param userSearchVO 검색조건
-	 * @param mberManageVO 회원가입신청정보
-	 * @param commandMap   파라메터전달용 commandMap
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자단에서 회원 가입화면", description = "사용자단에서 회원가입화면에 필요한 값 생성", tags = {
-			"EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-	})
+	@Override
 	@GetMapping("/etc/member_insert")
 	public ResultVO sbscrbMberView(UserDefaultVO userSearchVO, MberManageVO mberManageVO,
-			@RequestParam Map<String, Object> commandMap) throws Exception {
+		@RequestParam Map<String, Object> commandMap) throws Exception {
 
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -536,17 +391,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 회원 약관확인
-	 * 
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자단에서 회원 약관확인", description = "사용자단에서 회원 약관확인에 필요한 값 생성", tags = {
-			"EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-	})
+	@Override
 	@GetMapping("/etc/member_agreement")
 	public ResultVO sbscrbEntrprsMber() throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -561,19 +406,7 @@ public class EgovMberManageApiController {
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
 	}
 
-	/**
-	 * 사용자아이디의 중복여부를 체크하여 사용가능여부를 확인
-	 * 
-	 * @param commandMap 파라메터전달용 commandMap
-	 * @return resultVO
-	 * @throws Exception
-	 */
-	@Operation(summary = "사용자아이디의 중복여부 체크처리", description = "사용자아이디의 중복여부 체크처리", tags = {
-			"EgovMberManageApiController" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "조회 성공"),
-			@ApiResponse(responseCode = "403", description = "인가된 사용자가 아님")
-	})
+	@Override
 	@GetMapping("/etc/member_checkid/{checkid}")
 	public ResultVO checkIdDplct(@PathVariable("checkid") String checkId) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

`EgovMberManageApiController`의 가독성 및 유지보수성 개선을 위해 **API 명세(@Swagger Annotation)와 비즈니스 로직을 분리**했습니다.

기존 컨트롤러 클래스에 산재해 있던 모든 스웨거 어노테이션(`@Tag`, `@Operation`, `@ApiResponses`, `@SecurityRequirement` 등)을 `EgovMberManageApi`라는 별도의 인터페이스로 추출했습니다. 이제 `EgovMberManageApiController`는 이 인터페이스를 **구현(implements)**하며, 컨트롤러 본연의 역할인 요청 처리 로직에만 집중하게 됩니다.

이러한 변경을 통해 다음과 같은 효과를 얻을 수 있습니다:

- **관심사 분리(Separation of Concerns)**: API의 명세와 실제 구현 로직이 명확히 구분되어 역할이 명료해집니다.
- **코드 가독성 향상**: 컨트롤러 클래스에서 수많은 어노테이션이 제거되어 코드가 훨씬 간결해졌으며, 한 눈에 비즈니스 로직을 파악하기 쉬워졌습니다.
- **유지보수 용이성**: API 명세 변경이 필요할 경우 인터페이스 파일만 수정하면 되므로, 컨트롤러 구현부에 영향을 주지 않아 유지보수가 훨씬 용이해집니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### [적용 전]
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/71671d2f-4f80-4912-9f4f-71ba3165ed66" />

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/ba98e798-d1aa-4c07-b55e-26ce7c38b3dd" />

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/6f72648f-eefe-4431-8b5a-add9f0382cdc" />


### [적용 후]
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/221cc27b-4c41-4796-8847-3b0ec13ba319" />

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/d910fb47-6321-45d2-a54b-b9982babc7a8" />


<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/7e73fad1-1c8f-4e2c-af9c-718d4a5d1c49" />
