### PR TITLE
Fix HSQLDB compatibility by replacing MySQL DATE_FORMAT with TO_CHAR

### DIFF
--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml
@@ -53,7 +53,7 @@
 			         , MBTLNUM				AS MOBL_PHON_NO
 			         , GROUP_ID				AS GROUP_ID
 			         , EMPLYR_STTUS_CODE	AS STTUS
-			         , DATE_FORMAT(SBSCRB_DE, '%Y-%m-%d %H:%i:%s') AS SBSCR_DE
+                     , TO_CHAR(SBSCRB_DE, 'YYYY-MM-DD HH24:MI:SS') AS SBSCR_DE
 			      FROM    LETTNEMPLYRINFO
 				) A
 	     WHERE 1=1
@@ -86,7 +86,7 @@
 			         , MBTLNUM				AS MOBL_PHON_NO
 			         , GROUP_ID				AS GROUP_ID
 			         , EMPLYR_STTUS_CODE	AS STTUS
-			         , DATE_FORMAT(SBSCRB_DE, '%Y-%m-%d %H:%i:%s') AS SBSCR_DE
+                     , TO_CHAR(SBSCRB_DE, 'YYYY-MM-DD HH24:MI:SS') AS SBSCR_DE
 			      FROM LETTNEMPLYRINFO
 	    		) A
          WHERE 1=1


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

```sql
- , DATE_FORMAT(SBSCRB_DE, '%Y-%m-%d %H:%i:%s') AS SBSCR_DE
+ , TO_CHAR(SBSCRB_DE, 'YYYY-MM-DD HH24:MI:SS') AS SBSCR_DE
```

- MySQL 문법(`DATE_FORMAT`)을 HSQLDB 호환 문법(`TO_CHAR`)으로 변경
- 포맷 문자열도 HSQLDB 스타일로 수정 (`%Y-%m-%d %H:%i:%s` → `'YYYY-MM-DD HH24:MI:SS'`)

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

https://github.com/eGovFramework/egovframe-template-simple-backend/issues/99