### PR TITLE
Fix SQLSyntaxError in HSQLDB by correcting column name casing

### DIFF
--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml
@@ -61,12 +61,12 @@
 	    	sttus LIKE CONCAT('%' , #{sbscrbSttus}, '%')
 	    </if>
 	    <if test="searchCondition == 0">AND
-	    	userId LIKE CONCAT('%' , #{searchKeyword}, '%')
+	    	USER_ID LIKE CONCAT('%' , #{searchKeyword}, '%')
 	    </if>
 	    <if test="searchCondition == 1">AND
-	    	userNm LIKE CONCAT('%' , #{searchKeyword}, '%')
+	    	USER_NM LIKE CONCAT('%' , #{searchKeyword}, '%')
 	    </if>
-	     ORDER BY sbscrbDe DESC
+	     ORDER BY SBSCR_DE DESC
 	     LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
    	</select>
     	


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

```sql
- userId LIKE CONCAT('%', #{searchKeyword}, '%')
+ USER_ID LIKE CONCAT('%', #{searchKeyword}, '%')

- userNm LIKE CONCAT('%' , #{searchKeyword}, '%')
+ USER_NM LIKE CONCAT('%' , #{searchKeyword}, '%')

- ORDER BY sbscrbDe DESC
+ ORDER BY SBSCR_DE DESC
```
- 서브쿼리 alias와 외부 참조 컬럼의 대소문자 일치
- HSQLDB SQLSyntaxError 해결

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

https://github.com/eGovFramework/egovframe-template-simple-backend/issues/99
