### PR TITLE
refactor: 읽기 로직 개선 (StringBuilder,try-with-resource)

### DIFF
--- a/src/main/java/egovframework/com/cmm/AltibaseClobStringTypeHandler.java
+++ b/src/main/java/egovframework/com/cmm/AltibaseClobStringTypeHandler.java
@@ -40,8 +40,8 @@ import lombok.extern.slf4j.Slf4j;
  * large enough binary type will work.
  *
  * @author Juergen Hoeller
- * @since 1.1.5
  * @see org.springframework.orm.ibatis.SqlMapClientFactoryBean#setLobHandler
+ * @since 1.1.5
  */
 @Slf4j
 @SuppressWarnings("deprecation")
@@ -71,35 +71,26 @@ public class AltibaseClobStringTypeHandler extends AbstractLobTypeHandler {
 	}
 
 
-	@Override
-	protected Object getResultInternal(ResultSet rs, int index, LobHandler lobHandler)
-			throws SQLException {
+    @Override
+    protected Object getResultInternal(ResultSet rs, int index, LobHandler lobHandler)
+            throws SQLException {
 
-		StringBuffer read_data = new StringBuffer("");
-	    int read_length;
+        char[] buf = new char[1024];
+        StringBuilder readData = new StringBuilder(buf.length);
 
-		char [] buf = new char[1024];
+        Reader rd = lobHandler.getClobAsCharacterStream(rs, index);
+        int readLength;
+        try (Reader r = rd) {
+            while ((readLength = r.read(buf)) != -1) {
+                readData.append(buf, 0, readLength);
+            }
+        } catch (IOException ie) {
+            log.debug("ie: {}", ie);//SQLException sqle = new SQLException(ie.getMessage());
+            //throw sqle;
+            // 2011.10.10 보안점검 후속조치
+        }
+        return readData.toString();
 
-		Reader rd =  lobHandler.getClobAsCharacterStream(rs, index);
-	    try {
-			while( (read_length=rd.read(buf))  != -1) {
-				read_data.append(buf, 0, read_length);
-			}
-	    } catch (IOException ie) {
-	    	log.debug("ie: {}", ie);//SQLException sqle = new SQLException(ie.getMessage());
-	    	//throw sqle;
-    	// 2011.10.10 보안점검 후속조치
-	    } finally {
-		    
-			try {
-			    rd.close();
-			} catch (IOException ignore) {
-				log.debug("IGNORE: {}", ignore.getMessage());
-			}
-		    
-		}
-
-	    return read_data.toString();
 
 		//return lobHandler.getClobAsString(rs, index);
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

1. 로컬 변수로 스레드 안전성이 필요하지 않음으로  `StringBuffer` 사용을 `StringBuilder` 로 변경했습니다.  

2. `try-catch` 로직을  , `try-with-resource` 로 간결하게 표현했습니다.

3. `read_length` 변수명을 `readLength` 로 변경했습니다. 

나머지 로직은 원본과 그대로입니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
