### PR TITLE
Fix(mysql): SYSDATE()를 NOW()로 변경하여 타임스탬프 일관성 보장

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_mysql.xml
@@ -50,7 +50,7 @@
 			INSERT INTO LETTNFILE
 			(ATCH_FILE_ID, CREAT_DT, USE_AT)
 			VALUES
-			( #{atchFileId}, SYSDATE(), 'Y')			
+			( #{atchFileId}, NOW(), 'Y')
 		
 	</insert>
 	

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
@@ -53,7 +53,7 @@
 			VALUES
 			( #{bbsId}, #{bbsTyCode}, #{bbsAttrbCode}, #{bbsNm}, #{bbsIntrcn}, 
 			  #{replyPosblAt}, #{fileAtchPosblAt}, #{posblAtchFileNumber}, 
-			  #{posblAtchFileSize}, #{tmplatId}, #{useAt}, #{frstRegisterId}, SYSDATE()  
+			  #{posblAtchFileSize}, #{tmplatId}, #{useAt}, #{frstRegisterId}, NOW()
 			 )			
 		
 	</insert>
@@ -157,7 +157,7 @@
 				ATCH_POSBL_FILE_SIZE = #{posblAtchFileSize},
 				TMPLAT_ID = #{tmplatId},		
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
  		
  	</update>
@@ -167,7 +167,7 @@
 			UPDATE LETTNBBSMASTER SET 
 				USE_AT = 'N',
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
  		
  	</update>

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
@@ -96,7 +96,7 @@
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
 			  #{parnts}, 1, #{replyLc}, #{atchFileId},
-			  #{frstRegisterId}, SYSDATE(), 'Y'
+			  #{frstRegisterId}, NOW(), 'Y'
 			 )			
 		
 	</insert>
@@ -119,7 +119,7 @@
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
 			  #{parnts}, 1, #{replyLc}, #{atchFileId},
-			  #{frstRegisterId}, SYSDATE(), 'Y'
+			  #{frstRegisterId}, NOW(), 'Y'
 			 )			
 		
 	</insert>	
@@ -236,7 +236,7 @@
 				NTCE_ENDDE = #{ntceEndde},
 				LAST_UPDUSR_ID = #{lastUpdusrId},
 				ATCH_FILE_ID = #{atchFileId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
 			AND NTT_ID = #{nttId}
  		
@@ -248,7 +248,7 @@
 				NTT_SJ = #{nttSj},
 				USE_AT = 'N',
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
 			AND NTT_ID = #{nttId}
  		
@@ -282,7 +282,7 @@
 			UPDATE LETTNBBS SET 
 				RDCNT = #{inqireCo},
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
 			AND NTT_ID = #{nttId}
  		

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_mysql.xml
@@ -41,7 +41,7 @@
 			UPDATE LETTNBBSUSE SET 
 				USE_AT = 'N',
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
 			AND TRGET_ID = #{trgetId}	
 		
@@ -75,7 +75,7 @@
 			UPDATE LETTNBBSUSE SET 
 				USE_AT = 'N',
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE TRGET_ID = #{cmmntyId}
 		
 	</update>
@@ -94,7 +94,7 @@
 			UPDATE LETTNBBSUSE SET 
 				USE_AT = 'N',
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE TRGET_ID = #{clbId}
 		
 	</update>
@@ -105,7 +105,7 @@
 			(BBS_ID, TRGET_ID, REGIST_SE_CODE, USE_AT, 
 			 FRST_REGISTER_ID, FRST_REGIST_PNTTM )
 			VALUES
-			(#{bbsId}, #{trgetId}, #{registSeCode}, #{useAt}, #{frstRegisterId}, SYSDATE())
+			(#{bbsId}, #{trgetId}, #{registSeCode}, #{useAt}, #{frstRegisterId}, NOW())
 		
 	</insert>
 	
@@ -181,7 +181,7 @@
 			UPDATE LETTNBBSUSE SET 
 				USE_AT = #{useAt},
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
  		
  	</update>
@@ -191,7 +191,7 @@
 			UPDATE LETTNBBSUSE SET 
 				USE_AT = 'N',
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
 		
 	</update>
@@ -344,7 +344,7 @@
 			UPDATE LETTNBBSUSE SET 
 				USE_AT = #{useAt},
 				LAST_UPDUSR_ID = #{lastUpdusrId},
-				LAST_UPDT_PNTTM = SYSDATE()
+				LAST_UPDT_PNTTM = NOW()
 			WHERE BBS_ID = #{bbsId}
 			AND TRGET_ID = #{trgetId}	
 		

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
@@ -31,7 +31,7 @@
 	<!-- 메인페이지/일정관리조회 -->  
 	<select id="selectIndvdlSchdulManageMainList" parameterType="java.util.Map" resultType="egovMap">
 		SELECT 
-			DATE_FORMAT(sysdate(),'%Y-%m-%d') TO_DAY, 
+			DATE_FORMAT(NOW(),'%Y-%m-%d') TO_DAY,
 			A.SCHDUL_ID,
 			A.SCHDUL_SE,
 			A.SCHDUL_DEPT_ID,
@@ -56,9 +56,9 @@
 		
 		
 		AND ( 
-		 ( SUBSTRING(A.SCHDUL_BEGINDE,1,8) &gt; DATE_FORMAT(sysdate(),'%Y%m%d') AND SUBSTRING(A.SCHDUL_BEGINDE,1,8) &lt;= DATE_FORMAT(sysdate(),'%Y%m%d'))
+		 ( SUBSTRING(A.SCHDUL_BEGINDE,1,8) &gt; DATE_FORMAT(NOW(),'%Y%m%d') AND SUBSTRING(A.SCHDUL_BEGINDE,1,8) &lt;= DATE_FORMAT(NOW(),'%Y%m%d'))
 		OR
-		 ( SUBSTRING(A.SCHDUL_ENDDE,1,8) &gt;DATE_FORMAT(sysdate(),'%Y%m%d') AND SUBSTRING(A.SCHDUL_BEGINDE,1,8) &lt;= DATE_FORMAT(sysdate(),'%Y%m%d'))
+		 ( SUBSTRING(A.SCHDUL_ENDDE,1,8) &gt;DATE_FORMAT(NOW(),'%Y%m%d') AND SUBSTRING(A.SCHDUL_BEGINDE,1,8) &lt;= DATE_FORMAT(NOW(),'%Y%m%d'))
 		) 
 		
 		
@@ -232,7 +232,7 @@
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},
 			REPTIT_SE_CODE=#{reptitSeCode},
-			LAST_UPDT_PNTTM = sysdate(),
+			LAST_UPDT_PNTTM = NOW(),
 			LAST_UPDUSR_ID = #{lastUpdusrId}
 		WHERE SCHDUL_ID = #{schdulId}
 	</update>
@@ -300,9 +300,9 @@
 			#{schdulChargerId},
 			#{atchFileId},
 			#{reptitSeCode},    
-			sysdate(),
+			NOW(),
 			#{frstRegisterId},
-			sysdate(),
+			NOW(),
 			#{lastUpdusrId} 
 		)
 

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_mysql.xml
@@ -146,7 +146,7 @@
                 , #{mberFxnum}
                 , #{mberEmailAdres}
                 , #{middleTelno}
-                , sysdate()
+                , NOW()
         )
     </insert>
     

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/BbsTimestampConsistencyTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/BbsTimestampConsistencyTest.java
@@ -1,0 +1,63 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+@DisplayName("MySQL 타임스탬프 함수 동작 방식 비교")
+public class BbsTimestampConsistencyTest {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Test
+	@DisplayName("증명 1: SYSDATE()는 하나의 SQL문 내에서도 시간이 변경된다.")
+	void sysdate_is_inconsistent_in_a_single_statement() {
+		// 단 하나의 SQL 문: SYSDATE()를 호출하고, 1초 쉬고, 다시 SYSDATE()를 호출
+		String sql = "SELECT SYSDATE() AS time1, SLEEP(1), SYSDATE() AS time2";
+
+		// SQL 실행 및 결과 저장
+		Map<String, Object> result = jdbcTemplate.queryForMap(sql);
+		LocalDateTime time1 = (LocalDateTime) result.get("time1");
+		LocalDateTime time2 = (LocalDateTime) result.get("time2");
+
+		// 결과 출력
+		System.out.println("--- SYSDATE() 테스트 ---");
+		System.out.println("첫번째 시간: " + time1);
+		System.out.println("두번째 시간: " + time2);
+
+		// 검증: 두 시간은 반드시 달라야 한다.
+		assertNotEquals(time1, time2);
+		System.out.println("✅ 결론: SYSDATE()는 일관성을 지키지 못함.");
+	}
+
+	@Test
+	@DisplayName("증명 2: NOW()는 하나의 SQL문 내에서 시간이 고정된다.")
+	void now_is_consistent_in_a_single_statement() {
+		// 단 하나의 SQL 문: NOW()를 호출하고, 1초 쉬고, 다시 NOW()를 호출
+		String sql = "SELECT NOW() AS time1, SLEEP(1), NOW() AS time2";
+
+		// SQL 실행 및 결과 저장
+		Map<String, Object> result = jdbcTemplate.queryForMap(sql);
+		LocalDateTime time1 = (LocalDateTime) result.get("time1");
+		LocalDateTime time2 = (LocalDateTime) result.get("time2");
+
+		// 결과 출력
+		System.out.println("\n--- NOW() 테스트 ---");
+		System.out.println("첫번째 시간: " + time1);
+		System.out.println("두번째 시간: " + time2);
+
+		// 검증: 두 시간은 반드시 같아야 한다.
+		assertEquals(time1, time2);
+		System.out.println("✅ 결론: NOW() 일관성을 지킴.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

  - [X] 버그수정 Bug fixes
  - [ ] 기능개선 Enhancements
  - [ ] 기능추가 Adding features
  - [ ] 기타 Others

MySQL에서 `SYSDATE()` 함수는 **호출되는 시점**의 시간을 반환하여, 단일 SQL문 내에서도 지연이 발생할 경우 타임스탬프가 다르게 기록될 수 있는 잠재적인 데이터 불일치 문제를 가지고 있습니다.

이를 문장의 **시작 시간을 기준**으로 일관된 타임스탬프를 반환하는 `NOW()` 함수로 변경하여 데이터 정합성을 보장하도록 수정합니다.

### 근거 자료: MySQL 공식 문서

<img width="1588" height="774" alt="image" src="https://github.com/user-attachments/assets/a6e72e5a-6d47-4e9e-a85b-db7c94a80a31" />

이러한 동작 방식의 차이는 MySQL 8.4 공식 레퍼런스 문서에도 명시되어 있습니다.

**Reference:** [[MySQL 8.4 Manual / Date and Time Functions](https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html)]

> `NOW()` returns a constant time that indicates the time at which the statement began to execute. (...) This differs from the behavior for `SYSDATE()`, which returns the exact time at which it executes.

**공식 문서 예제:**

```sql
mysql> SELECT NOW(), SLEEP(2), NOW();
+---------------------+----------+---------------------+
| NOW()               | SLEEP(2) | NOW()               |
+---------------------+----------+---------------------+
| 2006-04-12 13:47:36 |        0 | 2006-04-12 13:47:36 |
+---------------------+----------+---------------------+

mysql> SELECT SYSDATE(), SLEEP(2), SYSDATE();
+---------------------+----------+---------------------+
| SYSDATE()           | SLEEP(2) | SYSDATE()           |
+---------------------+----------+---------------------+
| 2006-04-12 13:47:44 |        0 | 2006-04-12 13:47:46 |
+---------------------+----------+---------------------+
```

-----

## 수정된 소스 내용 Modified source

1.  **`EgovBoard_SQL_mysql.xml`**

      * `insertBoardArticle`, `deleteBoardArticle` 등 여러 쿼리에서 사용되던 `SYSDATE()`를 `NOW()`로 모두 변경하여 일관성을 확보했습니다.

2.  **`BbsTimestampConsistencyTest.java` (신규 테스트)**

      * MySQL의 `SYSDATE()`와 `NOW()`가 단일 SQL문 내에서 어떻게 다르게 동작하는지 명확하게 증명하는 JUnit 테스트 코드를 추가했습니다.

-----

## JUnit 테스트 JUnit tests

  - [X] JUnit 테스트 JUnit tests
  - [X] 수동 테스트 Manual testing

### 테스트 결과 및 증명

공식 문서의 예제와 동일한 원리를 JUnit 테스트로 증명했습니다. 단일 SQL문 내에서 1초의 지연(`SLEEP(1)`)을 두고 각 함수의 반환값을 비교한 결과, `SYSDATE()`는 시간이 변경되고 `NOW()`는 시간이 고정됨을 확인했습니다.

**테스트 실행 결과 로그:**

```
--- SYSDATE() 테스트 ---
첫번째 시간: 2025-09-28T05:25:10
두번째 시간: 2025-09-28T05:25:11
✅ 결론: SYSDATE()는 일관성을 지키지 못함.

--- NOW() 테스트 ---
첫번째 시간: 2025-09-28T05:25:12
두번째 시간: 2025-09-28T05:25:12
✅ 결론: NOW()는 일관성을 지킴.
```

-----

## 테스트 환경 정보

테스트는 Docker를 사용한 임시 MySQL 8.0 데이터베이스 환경에서 진행했습니다.

-----

## 테스트 브라우저 Test Browser

이번 수정은 백엔드 로직 개선에 해당하므로 브라우저 테스트는 진행하지 않았습니다.

  - [ ] Chrome
  - [ ] Firefox
  - [ ] Edge
  - [ ] Safari
  - [ ] Opera
  - [ ] Internet Explorer
  - [ ] 기타 Others

-----

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

<img width="1728" height="570" alt="image" src="https://github.com/user-attachments/assets/dd412994-9e50-427d-a119-8a71101ded1a" />
