### PR TITLE
[chore] jjwt 0.12.6 → 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<log4j2.version>2.25.3</log4j2.version>
 		<slf4j.version>2.0.17</slf4j.version>
 		<log4jdbc.version>1.2</log4jdbc.version>
-		<jjwt.version>0.12.6</jjwt.version>
+		<jjwt.version>0.13.0</jjwt.version>
 		<icu4j.version>77.1</icu4j.version>
 		<tomcat-embed.version>10.1.52</tomcat-embed.version>
 		<commons-beanutils.version>1.11.0</commons-beanutils.version>


### PR DESCRIPTION
## 변경 사유
`<jjwt.version>0.12.6</jjwt.version>`을 `0.13.0`으로 업그레이드합니다. [jjwt 0.13.0 릴리스 노트](https://github.com/jwtk/jjwt/releases/tag/0.13.0)에 따르면 변경 사항은 `JacksonDeserializer`의 기존 private 생성자를 public으로 노출시킨 것 한 건뿐이며, 바이너리·소스 호환성이 유지됩니다.

## 변경 내용
- `pom.xml` 단일 줄: `<jjwt.version>0.12.6</jjwt.version>` → `0.13.0`

## 영향 범위
- 토큰 생성/검증 로직 코드 변경 없음
- 0.14.0 이상은 Java 8+ 요구가 있는데 본 프로젝트는 Java 17이라 무관

## 체크리스트
- [x] 단일 주제(jjwt 버전 정렬)
- [x] 5.0.x 브랜치 대상
- [x] 호출부 코드 변경 없음