### PR TITLE
[test][simple-backend] EgovLoginServiceImpl 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImplTest.java
+++ b/src/test/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImplTest.java
@@ -1,0 +1,153 @@
+package egovframework.let.uat.uia.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cmm.LoginVO;
+
+/**
+ * 일반 로그인 서비스 단위 테스트
+ * @author 공통서비스 개발팀
+ * @since 2026.05.28
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovLoginServiceImplTest {
+
+    @InjectMocks
+    private EgovLoginServiceImpl loginService;
+
+    @Mock
+    private LoginDAO loginDAO;
+
+    private LoginVO sampleLoginVO;
+
+    @BeforeEach
+    void setUp() {
+        sampleLoginVO = new LoginVO();
+        sampleLoginVO.setId("testUser");
+        sampleLoginVO.setPassword("plainPassword");
+        sampleLoginVO.setUserSe("USR");
+        sampleLoginVO.setName("홍길동");
+        sampleLoginVO.setEmail("test@example.com");
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - DB 조회 결과가 있으면 해당 VO를 반환한다")
+    void actionLogin_성공_로그인결과반환() throws Exception {
+        // given
+        LoginVO dbResult = new LoginVO();
+        dbResult.setId("testUser");
+        dbResult.setPassword("encryptedPassword");
+        given(loginDAO.actionLogin(any(LoginVO.class))).willReturn(dbResult);
+
+        // when
+        LoginVO result = loginService.actionLogin(sampleLoginVO);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("testUser");
+        assertThat(result.getPassword()).isEqualTo("encryptedPassword");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - DB 조회 결과가 없으면 빈 VO를 반환한다")
+    void actionLogin_실패_빈VO반환() throws Exception {
+        // given
+        given(loginDAO.actionLogin(any(LoginVO.class))).willReturn(null);
+
+        // when
+        LoginVO result = loginService.actionLogin(sampleLoginVO);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNull();
+        assertThat(result.getPassword()).isNull();
+    }
+
+    @Test
+    @DisplayName("로그인 시 비밀번호가 암호화되어 DAO에 전달된다")
+    void actionLogin_비밀번호암호화_DAO호출() throws Exception {
+        // given
+        given(loginDAO.actionLogin(any(LoginVO.class))).willReturn(null);
+        String originalPassword = sampleLoginVO.getPassword();
+
+        // when
+        loginService.actionLogin(sampleLoginVO);
+
+        // then
+        assertThat(sampleLoginVO.getPassword()).isNotEqualTo(originalPassword);
+        assertThat(sampleLoginVO.getPassword()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("아이디 찾기 - DB 조회 결과가 있으면 해당 VO를 반환한다")
+    void searchId_성공_ID반환() throws Exception {
+        // given
+        LoginVO dbResult = new LoginVO();
+        dbResult.setId("testUser");
+        given(loginDAO.searchId(any(LoginVO.class))).willReturn(dbResult);
+
+        // when
+        LoginVO result = loginService.searchId(sampleLoginVO);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("아이디 찾기 - DB 조회 결과가 없으면 빈 VO를 반환한다")
+    void searchId_실패_빈VO반환() throws Exception {
+        // given
+        given(loginDAO.searchId(any(LoginVO.class))).willReturn(null);
+
+        // when
+        LoginVO result = loginService.searchId(sampleLoginVO);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNull();
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 - 사용자 정보가 일치하면 임시 비밀번호를 발급하고 true를 반환한다")
+    void searchPassword_성공_임시비밀번호발급() throws Exception {
+        // given
+        LoginVO dbResult = new LoginVO();
+        dbResult.setId("testUser");
+        dbResult.setPassword("storedPassword");
+        given(loginDAO.searchPassword(any(LoginVO.class))).willReturn(dbResult);
+
+        // when
+        boolean result = loginService.searchPassword(sampleLoginVO);
+
+        // then
+        assertThat(result).isTrue();
+        then(loginDAO).should().updatePassword(any(LoginVO.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 - 사용자 정보가 일치하지 않으면 false를 반환하고 DB를 갱신하지 않는다")
+    void searchPassword_실패_false반환() throws Exception {
+        // given
+        given(loginDAO.searchPassword(any(LoginVO.class))).willReturn(null);
+
+        // when
+        boolean result = loginService.searchPassword(sampleLoginVO);
+
+        // then
+        assertThat(result).isFalse();
+        then(loginDAO).should(never()).updatePassword(any(LoginVO.class));
+    }
+}


### PR DESCRIPTION
로그인 서비스(`EgovLoginServiceImpl`)의 핵심 비즈니스 로직에 대한 Mockito 기반 순수 단위 테스트를 추가합니다.

**테스트 대상**: `egovframework.let.uat.uia.service.impl.EgovLoginServiceImpl`

**추가된 테스트 (7건)**
- `actionLogin`: 로그인 성공(DB 결과 반환), 로그인 실패(null → 빈 VO 반환), 비밀번호 암호화 검증
- `searchId`: 아이디 찾기 성공/실패(null → 빈 VO 반환)
- `searchPassword`: 임시 비밀번호 발급 성공 및 `updatePassword` DAO 호출 검증, 미매칭 시 false 반환 및 DB 갱신 없음 검증

**테스트 방식**
- `@ExtendWith(MockitoExtension.class)` + `@InjectMocks` / `@Mock` 으로 외부 의존성 격리
- DB, 파일 시스템 등 인프라 불필요 — 순수 서비스 로직만 검증

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 테스트 통과 확인 (7/7 pass)
