### PR TITLE
[refactor][5.0.x][simple-backend] uss/umt 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 가입약관VO클래스로서가입약관확인시 비지니스로직 처리용 항목을 구성한다.
  * @author 공통서비스 개발팀 조재영
@@ -13,14 +16,16 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatVO implements Serializable {
 	/**
 	 * serialVersionUID
@@ -29,60 +34,12 @@ public class StplatVO implements Serializable {
 
 	/** 약관아이디*/
     private String useStplatId;
-	
+
     /** 사용약관안내*/
     private String useStplatCn;
-    
+
     /** 정보동의안내*/
     private String infoProvdAgeCn;
-    
-    /**
-	 * useStplatId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUseStplatId() {
-		return useStplatId;
-	}
-
-	/**
-	 * useStplatId attribute 값을 설정한다.
-	 * @param useStplatId String
-	 */
-	public void setUseStplatId(String useStplatId) {
-		this.useStplatId = useStplatId;
-	}
-
-	/**
-	 * useStplatCn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUseStplatCn() {
-		return useStplatCn;
-	}
-
-	/**
-	 * useStplatCn attribute 값을 설정한다.
-	 * @param useStplatCn String
-	 */
-	public void setUseStplatCn(String useStplatCn) {
-		this.useStplatCn = useStplatCn;
-	}
-
-	/**
-	 * infoProvdAgeCn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getInfoProvdAgeCn() {
-		return infoProvdAgeCn;
-	}
-
-	/**
-	 * infoProvdAgeCn attribute 값을 설정한다.
-	 * @param infoProvdAgeCn String
-	 */
-	public void setInfoProvdAgeCn(String infoProvdAgeCn) {
-		this.infoProvdAgeCn = infoProvdAgeCn;
-	}
 
 	/**
      * toString 메소드를 대치한다.
@@ -90,5 +47,5 @@ public class StplatVO implements Serializable {
     public String toString() {
     	return ToStringBuilder.reflectionToString(this);
     }
-    
+
 }

--- a/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 사용자정보 VO클래스로서일반회원, 기업회원, 업무사용자의  비지니스로직 처리시 기타조건성 항목을 구성한다.
  * @author 공통서비스 개발팀 조재영
@@ -13,16 +16,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class UserDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -30,22 +35,22 @@ public class UserDefaultVO implements Serializable {
 
 	/** 검색조건-회원상태     (0, A, D, P)*/
     private String sbscrbSttus = "0";
-	
+
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -58,166 +63,6 @@ public class UserDefaultVO implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * sbscrbSttus attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbSttus() {
-		return sbscrbSttus;
-	}
-
-	/**
-	 * sbscrbSttus attribute 값을 설정한다.
-	 * @param sbscrbSttus String
-	 */
-	public void setSbscrbSttus(String sbscrbSttus) {
-		this.sbscrbSttus = sbscrbSttus;
-	}
-
-	/**
-	 * searchCondition attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
 	/**
      * toString 메소드를 대치한다.
      */


### PR DESCRIPTION
## 변경 사유

`uss/umt` 모듈 VO 클래스에 수동 작성된 getter/setter 보일러플레이트 제거 — Lombok `@Getter`/`@Setter` 어노테이션 활용

## 변경 내용

- `StplatVO`: 3개 필드 getter/setter 6개 메서드 제거, `@Getter` `@Setter` 적용
- `UserDefaultVO`: 10개 필드 getter/setter 20개 메서드 제거, `@Getter` `@Setter` 적용
- 두 클래스 모두 `import lombok.Getter;` / `import lombok.Setter;` 추가

## 영향 범위

`uss/umt` 모듈 한정. 외부 호출 시그니처(메서드명·반환타입) 변경 없음.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (Lombok이 동일 시그니처 생성)
- [x] pom.xml에 Lombok 의존성 및 annotationProcessorPaths 이미 설정되어 있음
