### PR TITLE
[refactor][공통컴포넌트] cmm/use CmmUseDAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
@@ -2,7 +2,8 @@ package egovframework.com.cmm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultCodeVO;
@@ -24,7 +25,10 @@ import egovframework.com.cmm.service.CmmnDetailCode;
  *
  */
 @Repository("cmmUseDAO")
-public class CmmUseDAO extends EgovAbstractMapper {
+public class CmmUseDAO {
+
+    @Resource(name = "cmmUseMapper")
+    private CmmUseMapper cmmUseMapper;
 
     /**
      * 주어진 조건에 따른 공통코드를 불러온다.
@@ -34,8 +38,8 @@ public class CmmUseDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO vo) throws Exception {
-		return selectList("CmmUseDAO.selectCmmCodeDetail", vo);
-	}
+        return cmmUseMapper.selectCmmCodeDetail(vo);
+    }
 
     /**
      * 공통코드로 사용할 조직정보를 불러온다.
@@ -45,8 +49,8 @@ public class CmmUseDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO vo) throws Exception {
-		return selectList("CmmUseDAO.selectOgrnztIdDetail", vo);
-	}
+        return cmmUseMapper.selectOgrnztIdDetail(vo);
+    }
 
     /**
      * 공통코드로 사용할그룹정보를 불러온다.
@@ -56,6 +60,7 @@ public class CmmUseDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO vo) throws Exception {
-		return selectList("CmmUseDAO.selectGroupIdDetail", vo);
-	}
+        return cmmUseMapper.selectGroupIdDetail(vo);
+    }
+
 }

--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseMapper.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseMapper.java
@@ -1,0 +1,55 @@
+package egovframework.com.cmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+
+/**
+ * @Class Name : CmmUseMapper.java
+ * @Description : 공통코드등 전체 업무에서 공용해서 사용해야 하는 서비스를 정의하기위한 매퍼 인터페이스
+ * @Modification Information
+ *
+ *    수정일       수정자         수정내용
+ *    -------        -------     -------------------
+ *    2009. 3. 11.     이삼섭
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009. 3. 11.
+ * @version
+ * @see
+ *
+ */
+@EgovMapper
+public interface CmmUseMapper {
+
+    /**
+     * 주어진 조건에 따른 공통코드를 불러온다.
+     *
+     * @param vo
+     * @return
+     * @throws Exception
+     */
+    List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO vo) throws Exception;
+
+    /**
+     * 공통코드로 사용할 조직정보를 불러온다.
+     *
+     * @param vo
+     * @return
+     * @throws Exception
+     */
+    List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO vo) throws Exception;
+
+    /**
+     * 공통코드로 사용할 그룹정보를 불러온다.
+     *
+     * @param vo
+     * @return
+     * @throws Exception
+     */
+    List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -93,5 +94,13 @@ public class EgovConfigAppMapper {
 	public SqlSessionTemplate egovSqlSessionTemplate(@Qualifier("sqlSession") SqlSessionFactory sqlSession) {
 		SqlSessionTemplate sqlSessionTemplate = new SqlSessionTemplate(sqlSession);
 		return sqlSessionTemplate;
+	}
+
+	@Bean
+	public MapperConfigurer cmmUseMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.com.cmm.service.impl");
+		mapperConfigurer.setSqlSessionFactoryBeanName("sqlSession");
+		return mapperConfigurer;
 	}
 }

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: cmm/use CmmUseDAO
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경, mapper 스캐너 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
