### PR TITLE
[refactor][main] cop/bbs BBSManageDAO·BBSAttributeManageDAO @EgovMapper 방식 전환

### DIFF
--- a/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -93,5 +94,12 @@ public class EgovConfigAppMapper {
 	public SqlSessionTemplate egovSqlSessionTemplate(@Qualifier("sqlSession") SqlSessionFactory sqlSession) {
 		SqlSessionTemplate sqlSessionTemplate = new SqlSessionTemplate(sqlSession);
 		return sqlSessionTemplate;
+	}
+
+	@Bean
+	public MapperConfigurer bbsMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.let.cop.bbs.domain.repository");
+		return mapperConfigurer;
 	}
 }

--- a/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSAttributeManageDAO.java
+++ b/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSAttributeManageDAO.java
@@ -1,7 +1,8 @@
 package egovframework.let.cop.bbs.domain.repository;
+
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.bbs.domain.model.BoardMaster;
@@ -26,7 +27,10 @@ import egovframework.let.cop.bbs.dto.request.BbsAttributeUpdateRequestDTO;
  *  </pre>
  */
 @Repository("BBSAttributeManageDAO")
-public class BBSAttributeManageDAO extends EgovAbstractMapper {
+public class BBSAttributeManageDAO {
+
+    @Resource
+    private BBSAttributeManageMapper bbsAttributeManageMapper;
 
     /**
      * 등록된 게시판 속성정보를 삭제한다.
@@ -34,7 +38,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMaster
      */
     public void deleteBBSMasterInf(BoardMaster boardMaster) throws Exception {
-    	update("BBSAttributeManageDAO.deleteBBSMasterInf", boardMaster);
+        bbsAttributeManageMapper.deleteBBSMasterInf(boardMaster);
     }
 
     /**
@@ -43,7 +47,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMaster
      */
     public int insertBBSMasterInf(BoardMaster boardMaster) throws Exception {
-    	return insert("BBSAttributeManageDAO.insertBBSMasterInf", boardMaster);
+        return bbsAttributeManageMapper.insertBBSMasterInf(boardMaster);
     }
 
     /**
@@ -52,7 +56,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMasterVO
      */
     public BoardMasterVO selectBBSMasterInf(BoardMaster searchVO) throws Exception {
-    	return (BoardMasterVO)selectOne("BBSAttributeManageDAO.selectBBSMasterInf", searchVO);
+        return bbsAttributeManageMapper.selectBBSMasterInf(searchVO);
     }
 
     /**
@@ -61,8 +65,8 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMasterVO
      */
     public List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectBBSMasterInfs", vo);
-	}
+        return bbsAttributeManageMapper.selectBBSMasterInfs(vo);
+    }
 
     /**
      * 게시판 속성정보 목록 숫자를 조회한다
@@ -72,7 +76,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBBSMasterInfsCnt(BoardMasterVO vo) throws Exception {
-    	return (Integer)selectOne("BBSAttributeManageDAO.selectBBSMasterInfsCnt", vo);
+        return bbsAttributeManageMapper.selectBBSMasterInfsCnt(vo);
     }
 
     /**
@@ -81,7 +85,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMaster
      */
     public void updateBBSMasterInf(BoardMaster boardMaster) throws Exception {
-    	update("BBSAttributeManageDAO.updateBBSMasterInf", boardMaster);
+        bbsAttributeManageMapper.updateBBSMasterInf(boardMaster);
     }
 
     /**
@@ -90,7 +94,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMasterVO
      */
     public boolean validateTemplate(BoardMasterVO vo) throws Exception {
-    	return true;
+        return true;
     }
 
     /**
@@ -101,11 +105,12 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardMasterVO> selectAllBBSMasteInf(BoardMasterVO vo) throws Exception {
-		// 커뮤니티, 동호회의 게시판이 나오지 않도록 LETTNBBSUSE 테이블과 Join 필요
-		return selectList("BBSAttributeManageDAO.selectAllBBSMaster", vo);
-	}
+        // 커뮤니티, 동호회의 게시판이 나오지 않도록 LETTNBBSUSE 테이블과 Join 필요
+        return bbsAttributeManageMapper.selectAllBBSMaster(vo);
+    }
+
     public List<BoardMasterVO> selectAllBBSMasteInf(BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO) throws Exception {
-    	return selectList("BBSAttributeManageDAO.selectAllBBSMaster", bbsAttributeUpdateRequestDTO);
+        return bbsAttributeManageMapper.selectAllBBSMaster(bbsAttributeUpdateRequestDTO);
     }
 
     /**
@@ -114,8 +119,8 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMasterVO
      */
     public List<BoardMasterVO> selectBdMstrListByTrget(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectBdMstrListByTrget", vo);
-	}
+        return bbsAttributeManageMapper.selectBdMstrListByTrget(vo);
+    }
 
     /**
      * 사용중인 게시판 속성정보 목록 숫자를 조회한다
@@ -125,7 +130,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBdMstrListCntByTrget(BoardMasterVO vo) throws Exception {
-    	return (Integer)selectOne("BBSAttributeManageDAO.selectBdMstrListCntByTrget", vo);
+        return bbsAttributeManageMapper.selectBdMstrListCntByTrget(vo);
     }
 
     /**
@@ -136,8 +141,8 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardMasterVO> selectAllBdMstrByTrget(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectAllBdMstrByTrget", vo);
-	}
+        return bbsAttributeManageMapper.selectAllBdMstrByTrget(vo);
+    }
 
     /**
      * 사용 중이지 않은 게시판 속성정보 목록을 조회한다.
@@ -145,8 +150,8 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @param BoardMasterVO
      */
     public List<BoardMasterVO> selectNotUsedBdMstrList(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectNotUsedBdMstrList", vo);
-	}
+        return bbsAttributeManageMapper.selectNotUsedBdMstrList(vo);
+    }
 
     /**
      * 사용 중이지 않은 게시판 속성정보 목록 숫자를 조회한다
@@ -155,7 +160,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
      * @return
      * @throws Exception
      */
-	public int selectNotUsedBdMstrListCnt(BoardMasterVO vo) throws Exception {
-		return (Integer)selectOne("BBSAttributeManageDAO.selectNotUsedBdMstrListCnt", vo);
+    public int selectNotUsedBdMstrListCnt(BoardMasterVO vo) throws Exception {
+        return bbsAttributeManageMapper.selectNotUsedBdMstrListCnt(vo);
     }
 }

--- a/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSAttributeManageMapper.java
+++ b/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSAttributeManageMapper.java
@@ -1,0 +1,56 @@
+package egovframework.let.cop.bbs.domain.repository;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.bbs.domain.model.BoardMaster;
+import egovframework.let.cop.bbs.domain.model.BoardMasterVO;
+import egovframework.let.cop.bbs.dto.request.BbsAttributeUpdateRequestDTO;
+
+/**
+ * 게시판 속성정보 관리를 위한 Mapper 인터페이스
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.12
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.12  이삼섭          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ *  </pre>
+ */
+@EgovMapper
+public interface BBSAttributeManageMapper {
+
+    void deleteBBSMasterInf(BoardMaster boardMaster);
+
+    int insertBBSMasterInf(BoardMaster boardMaster);
+
+    BoardMasterVO selectBBSMasterInf(BoardMaster searchVO);
+
+    List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO vo);
+
+    Integer selectBBSMasterInfsCnt(BoardMasterVO vo);
+
+    void updateBBSMasterInf(BoardMaster boardMaster);
+
+    List<BoardMasterVO> selectAllBBSMaster(BoardMasterVO vo);
+
+    List<BoardMasterVO> selectAllBBSMaster(BbsAttributeUpdateRequestDTO dto);
+
+    List<BoardMasterVO> selectBdMstrListByTrget(BoardMasterVO vo);
+
+    Integer selectBdMstrListCntByTrget(BoardMasterVO vo);
+
+    List<BoardMasterVO> selectAllBdMstrByTrget(BoardMasterVO vo);
+
+    List<BoardMasterVO> selectNotUsedBdMstrList(BoardMasterVO vo);
+
+    Integer selectNotUsedBdMstrListCnt(BoardMasterVO vo);
+}

--- a/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSManageDAO.java
+++ b/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSManageDAO.java
@@ -1,9 +1,9 @@
 package egovframework.let.cop.bbs.domain.repository;
+
 import java.util.Iterator;
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
-
+import jakarta.annotation.Resource;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.bbs.domain.model.Board;
@@ -27,7 +27,10 @@ import egovframework.let.cop.bbs.domain.model.BoardVO;
  *  </pre>
  */
 @Repository("BBSManageDAO")
-public class BBSManageDAO extends EgovAbstractMapper {
+public class BBSManageDAO {
+
+    @Resource
+    private BBSManageMapper bbsManageMapper;
 
     /**
      * 게시판에 게시물을 등록 한다.
@@ -36,10 +39,10 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertBoardArticle(Board board) throws Exception {
-	long nttId = (Long)selectOne("BBSManageDAO.selectMaxNttId");
+	long nttId = bbsManageMapper.selectMaxNttId();
 	board.setNttId(nttId);
 
-	insert("BBSManageDAO.insertBoardArticle", board);
+	bbsManageMapper.insertBoardArticle(board);
     }
 
     /**
@@ -49,22 +52,22 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public long replyBoardArticle(Board board) throws Exception {
-	long nttId = (Long)selectOne("BBSManageDAO.selectMaxNttId");
+	long nttId = bbsManageMapper.selectMaxNttId();
 	board.setNttId(nttId);
 
-	insert("BBSManageDAO.replyBoardArticle", board);
+	bbsManageMapper.replyBoardArticle(board);
 
 	//----------------------------------------------------------
 	// 현재 글 이후 게시물에 대한 NTT_NO를 증가 (정렬을 추가하기 위해)
 	//----------------------------------------------------------
 	//String parentId = board.getParnts();
-	long nttNo = (Long)selectOne("BBSManageDAO.getParentNttNo", board);
+	long nttNo = bbsManageMapper.getParentNttNo(board);
 
 	board.setNttNo(nttNo);
-	update("BBSManageDAO.updateOtherNttNo", board);
+	bbsManageMapper.updateOtherNttNo(board);
 
 	board.setNttNo(nttNo + 1);
-	update("BBSManageDAO.updateNttNo", board);
+	bbsManageMapper.updateNttNo(board);
 
 	return nttId;
     }
@@ -77,7 +80,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public BoardVO selectBoardArticle(BoardVO boardVO) throws Exception {
-    	return (BoardVO)selectOne("BBSManageDAO.selectBoardArticle", boardVO);
+    	return bbsManageMapper.selectBoardArticle(boardVO);
     }
 
     /**
@@ -88,7 +91,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectBoardArticleList(BoardVO boardVO) throws Exception {
-		return selectList("BBSManageDAO.selectBoardArticleList", boardVO);
+		return bbsManageMapper.selectBoardArticleList(boardVO);
 	}
 
     /**
@@ -99,7 +102,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBoardArticleListCnt(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectBoardArticleListCnt", boardVO);
+    	return bbsManageMapper.selectBoardArticleListCnt(boardVO);
     }
 
     /**
@@ -109,7 +112,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBoardArticle(Board board) throws Exception {
-    	update("BBSManageDAO.updateBoardArticle", board);
+    	bbsManageMapper.updateBoardArticle(board);
     }
 
     /**
@@ -119,7 +122,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBoardArticle(Board board) throws Exception {
-    	update("BBSManageDAO.deleteBoardArticle", board);
+    	bbsManageMapper.deleteBoardArticle(board);
     }
 
     /**
@@ -129,7 +132,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateInqireCo(BoardVO boardVO) throws Exception {
-    	update("BBSManageDAO.updateInqireCo", boardVO);
+    	bbsManageMapper.updateInqireCo(boardVO);
     }
 
     /**
@@ -140,7 +143,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectMaxInqireCo(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectMaxInqireCo", boardVO);
+    	return bbsManageMapper.selectMaxInqireCo(boardVO);
     }
 
     /**
@@ -151,7 +154,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectNoticeListForSort(Board board) throws Exception {
-		return selectList("BBSManageDAO.selectNoticeListForSort", board);
+		return bbsManageMapper.selectNoticeListForSort(board);
 	}
 
     /**
@@ -165,7 +168,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
 	Iterator<BoardVO> iter = sortList.iterator();
 	while (iter.hasNext()) {
 	    vo = iter.next();
-	    update("BBSManageDAO.updateSortOrder", vo);
+	    bbsManageMapper.updateSortOrder(vo);
 	}
     }
 
@@ -177,7 +180,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public long selectNoticeItemForSort(Board board) throws Exception {
-    	return (Long)selectOne("BBSManageDAO.selectNoticeItemForSort", board);
+    	return bbsManageMapper.selectNoticeItemForSort(board);
     }
 
     /**
@@ -188,7 +191,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectGuestList(BoardVO boardVO) throws Exception {
-		return selectList("BBSManageDAO.selectGuestList", boardVO);
+		return bbsManageMapper.selectGuestList(boardVO);
 	}
 
     /**
@@ -199,7 +202,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectGuestListCnt(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectGuestListCnt", boardVO);
+    	return bbsManageMapper.selectGuestListCnt(boardVO);
     }
 
     /**
@@ -209,7 +212,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteGuestList(BoardVO boardVO) throws Exception {
-    	update("BBSManageDAO.deleteGuestList", boardVO);
+    	bbsManageMapper.deleteGuestList(boardVO);
     }
 
     /**
@@ -220,6 +223,6 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public String getPasswordInf(Board board) throws Exception {
-    	return (String)selectOne("BBSManageDAO.getPasswordInf", board);
+    	return bbsManageMapper.getPasswordInf(board);
     }
 }

--- a/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSManageMapper.java
+++ b/src/main/java/egovframework/let/cop/bbs/domain/repository/BBSManageMapper.java
@@ -1,0 +1,69 @@
+package egovframework.let.cop.bbs.domain.repository;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.bbs.domain.model.Board;
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+
+/**
+ * 게시물 관리를 위한 Mapper 인터페이스
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.19
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.19  이삼섭          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ *  </pre>
+ */
+@EgovMapper
+public interface BBSManageMapper {
+
+    Long selectMaxNttId();
+
+    void insertBoardArticle(Board board);
+
+    void replyBoardArticle(Board board);
+
+    Long getParentNttNo(Board board);
+
+    void updateOtherNttNo(Board board);
+
+    void updateNttNo(Board board);
+
+    BoardVO selectBoardArticle(BoardVO boardVO);
+
+    List<BoardVO> selectBoardArticleList(BoardVO boardVO);
+
+    Integer selectBoardArticleListCnt(BoardVO boardVO);
+
+    void updateBoardArticle(Board board);
+
+    void deleteBoardArticle(Board board);
+
+    void updateInqireCo(BoardVO boardVO);
+
+    Integer selectMaxInqireCo(BoardVO boardVO);
+
+    List<BoardVO> selectNoticeListForSort(Board board);
+
+    void updateSortOrder(BoardVO boardVO);
+
+    Long selectNoticeItemForSort(Board board);
+
+    List<BoardVO> selectGuestList(BoardVO boardVO);
+
+    Integer selectGuestListCnt(BoardVO boardVO);
+
+    void deleteGuestList(BoardVO boardVO);
+
+    String getPasswordInf(Board board);
+}

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.domain.model.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.domain.model.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.domain.model.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.domain.model.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.domain.model.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.domain.model.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.domain.model.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.domain.model.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.domain.model.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.domain.model.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.domain.model.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.domain.repository.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.domain.model.BoardVO">


### PR DESCRIPTION
## 변경 사유

cop/bbs 모듈의 BBSManageDAO·BBSAttributeManageDAO가 EgovAbstractMapper를 직접 상속하는 구조로 되어 있었다. eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 활용하여 Mapper 인터페이스 위임 구조로 전환한다.

## 변경 내용

- `BBSManageMapper` 인터페이스 신규 추가 (`@EgovMapper`)
  - XML statement id와 동일한 메서드명으로 구성
- `BBSAttributeManageMapper` 인터페이스 신규 추가 (`@EgovMapper`)
  - `selectAllBBSMaster` 오버로드 포함 (BoardMasterVO, BbsAttributeUpdateRequestDTO)
- `BBSManageDAO`: EgovAbstractMapper 상속 제거, BBSManageMapper 위임으로 전환
  - 기존 public 메서드명·시그니처 완전 유지 (ServiceImpl 무변경)
- `BBSAttributeManageDAO`: 동일 패턴으로 전환
  - `selectAllBBSMasteInf` → mapper의 `selectAllBBSMaster` 호출 (DAO 메서드명 유지)
- XML namespace를 mapper 인터페이스 FQN으로 변경 (statement id·SQL 내용 불변)
  - `EgovBoard_SQL_*.xml` 6개: `BBSManageDAO` → `egovframework.let.cop.bbs.domain.repository.BBSManageMapper`
  - `EgovBBSMaster_SQL_*.xml` 6개: `BBSAttributeManageDAO` → `egovframework.let.cop.bbs.domain.repository.BBSAttributeManageMapper`
- `EgovConfigAppMapper`에 `bbsMapperConfigurer` 빈 등록 (`basePackage=egovframework.let.cop.bbs.domain.repository`)

## 영향 범위

- ServiceImpl(`EgovBBSManageServiceImpl`, `EgovBBSAttributeManageServiceImpl`) 변경 없음
- XML statement id·SQL 내용 변경 없음
- DAO public 메서드 시그니처 변경 없음

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (ServiceImpl·XML statement 무변경)
- [x] `mvn compile -DskipTests` 통과 확인
