### PR TITLE
[refactor][main] uat/uia·uat/esm·uss/umt DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -93,5 +94,29 @@ public class EgovConfigAppMapper {
 	public SqlSessionTemplate egovSqlSessionTemplate(@Qualifier("sqlSession") SqlSessionFactory sqlSession) {
 		SqlSessionTemplate sqlSessionTemplate = new SqlSessionTemplate(sqlSession);
 		return sqlSessionTemplate;
+	}
+
+	@Bean
+	public MapperConfigurer loginMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.let.uat.uia.service.impl");
+		mapperConfigurer.setSqlSessionFactoryBeanName("sqlSession");
+		return mapperConfigurer;
+	}
+
+	@Bean
+	public MapperConfigurer siteManagerMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.let.uat.esm.service.impl");
+		mapperConfigurer.setSqlSessionFactoryBeanName("sqlSession");
+		return mapperConfigurer;
+	}
+
+	@Bean
+	public MapperConfigurer mberManageMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.let.uss.umt.service.impl");
+		mapperConfigurer.setSqlSessionFactoryBeanName("sqlSession");
+		return mapperConfigurer;
 	}
 }

--- a/src/main/java/egovframework/let/uat/esm/service/impl/SiteManagerMapper.java
+++ b/src/main/java/egovframework/let/uat/esm/service/impl/SiteManagerMapper.java
@@ -2,11 +2,10 @@ package egovframework.let.uat.esm.service.impl;
 
 import java.util.Map;
 
-import jakarta.annotation.Resource;
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 /**
- * 사이트관리자의 로그인 비밀번호를 변경 처리하는 비즈니스 구현 클래스
+ * 사이트관리자의 로그인 비밀번호를 변경 처리하는 매퍼 인터페이스
  * @author 공통서비스 개발팀
  * @since 2023.04.15
  * @version 1.0
@@ -21,11 +20,8 @@ import org.springframework.stereotype.Repository;
  *
  *  </pre>
  */
-@Repository("siteManagerDAO")
-public class SiteManagerDAO {
-
-	@Resource(name = "siteManagerMapper")
-	private SiteManagerMapper siteManagerMapper;
+@EgovMapper
+public interface SiteManagerMapper {
 
 	/**
 	 * 기존 비번과 비교하여 변경된 비밀번호를 저장한다.
@@ -33,7 +29,6 @@ public class SiteManagerDAO {
 	 * @return 성공시 1
 	 * @exception Exception
 	 */
-	public Integer updateAdminPassword(Map<?, ?> map) throws Exception {
-		return siteManagerMapper.updateAdminPassword(map);
-	}
+	Integer updateAdminPassword(Map<?, ?> map) throws Exception;
+
 }

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
@@ -1,12 +1,11 @@
 package egovframework.let.uat.uia.service.impl;
 
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
 import egovframework.com.cmm.LoginVO;
 
-import jakarta.annotation.Resource;
-import org.springframework.stereotype.Repository;
-
 /**
- * 일반 로그인을 처리하는 비즈니스 구현 클래스
+ * 일반 로그인을 처리하는 매퍼 인터페이스
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.06
  * @version 1.0
@@ -22,11 +21,8 @@ import org.springframework.stereotype.Repository;
  *
  *  </pre>
  */
-@Repository("loginDAO")
-public class LoginDAO {
-
-	@Resource(name = "loginMapper")
-	private LoginMapper loginMapper;
+@EgovMapper
+public interface LoginMapper {
 
 	/**
 	 * 일반 로그인을 처리한다
@@ -34,9 +30,7 @@ public class LoginDAO {
 	 * @return LoginVO
 	 * @exception Exception
 	 */
-	public LoginVO actionLogin(LoginVO vo) throws Exception {
-		return loginMapper.actionLogin(vo);
-	}
+	LoginVO actionLogin(LoginVO vo) throws Exception;
 
 	/**
 	 * 아이디를 찾는다.
@@ -44,9 +38,7 @@ public class LoginDAO {
 	 * @return LoginVO
 	 * @exception Exception
 	 */
-	public LoginVO searchId(LoginVO vo) throws Exception {
-		return loginMapper.searchId(vo);
-	}
+	LoginVO searchId(LoginVO vo) throws Exception;
 
 	/**
 	 * 비밀번호를 찾는다.
@@ -54,16 +46,13 @@ public class LoginDAO {
 	 * @return LoginVO
 	 * @exception Exception
 	 */
-	public LoginVO searchPassword(LoginVO vo) throws Exception {
-		return loginMapper.searchPassword(vo);
-	}
+	LoginVO searchPassword(LoginVO vo) throws Exception;
 
 	/**
 	 * 변경된 비밀번호를 저장한다.
 	 * @param vo LoginVO
 	 * @exception Exception
 	 */
-	public void updatePassword(LoginVO vo) throws Exception {
-		loginMapper.updatePassword(vo);
-	}
+	void updatePassword(LoginVO vo) throws Exception;
+
 }

--- a/src/main/java/egovframework/let/uss/umt/service/impl/MberManageDAO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/MberManageDAO.java
@@ -2,7 +2,7 @@ package egovframework.let.uss.umt.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
 
 import egovframework.let.uss.umt.service.MberManageVO;
 import egovframework.let.uss.umt.service.UserDefaultVO;
@@ -27,16 +27,18 @@ import org.springframework.stereotype.Repository;
  * </pre>
  */
 @Repository("mberManageDAO")
-public class MberManageDAO extends EgovAbstractMapper{
+public class MberManageDAO {
+
+    @Resource(name = "mberManageMapper")
+    private MberManageMapper mberManageMapper;
 
     /**
      * 기 등록된 특정 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
      * @param userSearchVO 검색조건
      * @return List<MberManageVO> 기업회원 목록정보
      */
-    @SuppressWarnings("unchecked")
-	public List<MberManageVO> selectMberList(UserDefaultVO userSearchVO){
-        return selectList("mberManageDAO.selectMberList", userSearchVO);
+    public List<MberManageVO> selectMberList(UserDefaultVO userSearchVO) {
+        return mberManageMapper.selectMberList(userSearchVO);
     }
 
     /**
@@ -45,15 +47,15 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return int 일반회원총갯수
      */
     public int selectMberListTotCnt(UserDefaultVO userSearchVO) {
-        return selectOne("mberManageDAO.selectMberListTotCnt", userSearchVO);
+        return mberManageMapper.selectMberListTotCnt(userSearchVO);
     }
 
     /**
      * 화면에 조회된 일반회원의 정보를 데이터베이스에서 삭제
      * @param delId 삭제 대상 일반회원아이디
      */
-    public void deleteMber(String delId){
-        delete("mberManageDAO.deleteMber_S", delId);
+    public void deleteMber(String delId) {
+        mberManageMapper.deleteMber_S(delId);
     }
 
     /**
@@ -61,25 +63,25 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param mberManageVO 일반회원 등록정보
      * @return String 등록결과
      */
-    public int insertMber(MberManageVO mberManageVO){
-        return insert("mberManageDAO.insertMber_S", mberManageVO);
+    public int insertMber(MberManageVO mberManageVO) {
+        return mberManageMapper.insertMber_S(mberManageVO);
     }
 
     /**
-     * 기 등록된 사용자 중 검색조건에 맞는일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
+     * 기 등록된 사용자 중 검색조건에 맞는 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
      * @param mberId 상세조회대상 일반회원아이디
      * @return MberManageVO 일반회원 상세정보
      */
-    public MberManageVO selectMber(String mberId){
-        return (MberManageVO) selectOne("mberManageDAO.selectMber_S", mberId);
+    public MberManageVO selectMber(String mberId) {
+        return mberManageMapper.selectMber_S(mberId);
     }
 
     /**
-     * 화면에 조회된일반회원의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
+     * 화면에 조회된 일반회원의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
      * @param mberManageVO 일반회원수정정보
      */
-    public void updateMber(MberManageVO mberManageVO){
-        update("mberManageDAO.updateMber_S",mberManageVO);
+    public void updateMber(MberManageVO mberManageVO) {
+        mberManageMapper.updateMber_S(mberManageVO);
     }
 
     /**
@@ -87,8 +89,8 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param stplatId 일반회원약관아이디
      * @return List 일반회원약관정보
      */
-	public List<?> selectStplat(String stplatId){
-    	return selectList("mberManageDAO.selectStplat_S", stplatId);
+    public List<?> selectStplat(String stplatId) {
+        return mberManageMapper.selectStplat_S(stplatId);
     }
 
     /**
@@ -96,7 +98,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param passVO 기업회원수정정보(비밀번호)
      */
     public void updatePassword(MberManageVO passVO) {
-        update("mberManageDAO.updatePassword_S", passVO);
+        mberManageMapper.updatePassword_S(passVO);
     }
 
     /**
@@ -104,8 +106,8 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param mberManageVO 일반회원암호 조회조건정보
      * @return MberManageVO 일반회원 암호정보
      */
-    public MberManageVO selectPassword(MberManageVO mberManageVO){
-    	return (MberManageVO) selectOne("mberManageDAO.selectPassword_S", mberManageVO);
+    public MberManageVO selectPassword(MberManageVO mberManageVO) {
+        return mberManageMapper.selectPassword_S(mberManageVO);
     }
 
     /**
@@ -113,8 +115,8 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param checkId 중복체크대상 아이디
      * @return int 사용가능여부(아이디 사용회수 )
      */
-    public int checkIdDplct(String checkId){
-        return (Integer)selectOne("mberManageDAO.checkIdDplct_S", checkId);
+    public int checkIdDplct(String checkId) {
+        return mberManageMapper.checkIdDplct_S(checkId);
     }
 
 }

--- a/src/main/java/egovframework/let/uss/umt/service/impl/MberManageMapper.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/MberManageMapper.java
@@ -1,0 +1,97 @@
+package egovframework.let.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.umt.service.MberManageVO;
+import egovframework.let.uss.umt.service.UserDefaultVO;
+
+/**
+ * 일반회원관리에 관한 매퍼 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  JJY            최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2024.07.23  김일국          스프링부트용으로 커스터마이징
+ * </pre>
+ */
+@EgovMapper
+public interface MberManageMapper {
+
+	/**
+	 * 기 등록된 특정 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
+	 * @param userSearchVO 검색조건
+	 * @return List<MberManageVO> 일반회원 목록정보
+	 */
+	List<MberManageVO> selectMberList(UserDefaultVO userSearchVO);
+
+	/**
+	 * 일반회원 총 갯수를 조회한다.
+	 * @param userSearchVO 검색조건
+	 * @return int 일반회원총갯수
+	 */
+	int selectMberListTotCnt(UserDefaultVO userSearchVO);
+
+	/**
+	 * 화면에 조회된 일반회원의 정보를 데이터베이스에서 삭제
+	 * @param delId 삭제 대상 일반회원아이디
+	 */
+	void deleteMber_S(String delId);
+
+	/**
+	 * 일반회원의 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
+	 * @param mberManageVO 일반회원 등록정보
+	 * @return int 등록결과
+	 */
+	int insertMber_S(MberManageVO mberManageVO);
+
+	/**
+	 * 기 등록된 사용자 중 검색조건에 맞는 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
+	 * @param mberId 상세조회대상 일반회원아이디
+	 * @return MberManageVO 일반회원 상세정보
+	 */
+	MberManageVO selectMber_S(String mberId);
+
+	/**
+	 * 화면에 조회된 일반회원의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
+	 * @param mberManageVO 일반회원수정정보
+	 */
+	void updateMber_S(MberManageVO mberManageVO);
+
+	/**
+	 * 일반회원 약관확인
+	 * @param stplatId 일반회원약관아이디
+	 * @return List 일반회원약관정보
+	 */
+	List<?> selectStplat_S(String stplatId);
+
+	/**
+	 * 일반회원 암호수정
+	 * @param passVO 일반회원수정정보(비밀번호)
+	 */
+	void updatePassword_S(MberManageVO passVO);
+
+	/**
+	 * 일반회원이 비밀번호를 기억하지 못할 때 비밀번호를 찾을 수 있도록 함
+	 * @param mberManageVO 일반회원암호 조회조건정보
+	 * @return MberManageVO 일반회원 암호정보
+	 */
+	MberManageVO selectPassword_S(MberManageVO mberManageVO);
+
+	/**
+	 * 입력한 사용자아이디의 중복여부를 체크하여 사용가능여부를 확인
+	 * @param checkId 중복체크대상 아이디
+	 * @return int 사용가능여부(아이디 사용회수)
+	 */
+	int checkIdDplct_S(String checkId);
+
+}

--- a/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteManagerDAO">
+<mapper namespace="egovframework.let.uat.esm.service.impl.SiteManagerMapper">
 
 	<!-- 사이트관리자용 변경된 비밀번호를 저장하는 쿼리 -->
 	<update id="updateAdminPassword" parameterType="java.util.Map">

--- a/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteManagerDAO">
+<mapper namespace="egovframework.let.uat.esm.service.impl.SiteManagerMapper">
 
 	<!-- 사이트관리자용 변경된 비밀번호를 저장하는 쿼리 -->
 	<update id="updateAdminPassword" parameterType="java.util.Map">

--- a/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteManagerDAO">
+<mapper namespace="egovframework.let.uat.esm.service.impl.SiteManagerMapper">
 
 	<!-- 사이트관리자용 변경된 비밀번호를 저장하는 쿼리 -->
 	<update id="updateAdminPassword" parameterType="java.util.Map">

--- a/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteManagerDAO">
+<mapper namespace="egovframework.let.uat.esm.service.impl.SiteManagerMapper">
 
 	<!-- 사이트관리자용 변경된 비밀번호를 저장하는 쿼리 -->
 	<update id="updateAdminPassword" parameterType="java.util.Map">

--- a/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteManagerDAO">
+<mapper namespace="egovframework.let.uat.esm.service.impl.SiteManagerMapper">
 
 	<!-- 사이트관리자용 변경된 비밀번호를 저장하는 쿼리 -->
 	<update id="updateAdminPassword" parameterType="java.util.Map">

--- a/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/esm/EgovSiteMgr_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteManagerDAO">
+<mapper namespace="egovframework.let.uat.esm.service.impl.SiteManagerMapper">
 
 	<!-- 사이트관리자용 변경된 비밀번호를 저장하는 쿼리 -->
 	<update id="updateAdminPassword" parameterType="java.util.Map">

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 	<resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">
         <result property="useStplatId"         column="USE_STPLAT_ID" />
         <result property="useStplatCn"         column="USE_STPLAT_CN" />

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 	<resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">
         <result property="useStplatId"         column="USE_STPLAT_ID" />
         <result property="useStplatCn"         column="USE_STPLAT_CN" />

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 	<resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">
         <result property="useStplatId"         column="USE_STPLAT_ID" />
         <result property="useStplatCn"         column="USE_STPLAT_CN" />

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 	<resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">
         <result property="useStplatId"         column="USE_STPLAT_ID" />
         <result property="useStplatCn"         column="USE_STPLAT_CN" />

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 	<resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">
         <result property="useStplatId"         column="USE_STPLAT_ID" />
         <result property="useStplatCn"         column="USE_STPLAT_CN" />

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 	<resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">
         <result property="useStplatId"         column="USE_STPLAT_ID" />
         <result property="useStplatCn"         column="USE_STPLAT_CN" />


### PR DESCRIPTION
uat/uia LoginDAO, uat/esm SiteManagerDAO, uss/umt MberManageDAO 세 곳에 @EgovMapper 인터페이스 방식을 도입합니다.

## 변경 내용

**새 Mapper 인터페이스 (3개)**
- `LoginMapper` — uat/uia, actionLogin / searchId / searchPassword / updatePassword
- `SiteManagerMapper` — uat/esm, updateAdminPassword
- `MberManageMapper` — uss/umt, selectMberList 외 8개 메서드

**DAO 변경 (3개)**
- EgovAbstractMapper 상속 제거, @Resource로 각 Mapper 인터페이스 주입 후 위임
- DAO 메서드명·ServiceImpl 호출부 무변경

**XML namespace (18개 파일, 3개 모듈 × 6개 DB)**
- statement id/내용 불변, namespace만 단순 문자열(loginDAO 등) → FQN으로 변경

**EgovConfigAppMapper**
- loginMapperConfigurer, siteManagerMapperConfigurer, mberManageMapperConfigurer 빈 추가

## 영향 범위

ServiceImpl 3개(EgovLoginServiceImpl, EgovSiteManagerServiceImpl, EgovMberManageServiceImpl) 미수정. 빌드(`mvn compile -DskipTests`) 정상.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (DAO 메서드명 유지, ServiceImpl 미수정)
- [x] 빌드 통과 확인
