### PR TITLE
[refactor][main] cop/com·smt/sim DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -93,5 +94,21 @@ public class EgovConfigAppMapper {
 	public SqlSessionTemplate egovSqlSessionTemplate(@Qualifier("sqlSession") SqlSessionFactory sqlSession) {
 		SqlSessionTemplate sqlSessionTemplate = new SqlSessionTemplate(sqlSession);
 		return sqlSessionTemplate;
+	}
+
+	@Bean
+	public MapperConfigurer bbsUseInfoManageMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.let.cop.com.service.impl");
+		mapperConfigurer.setSqlSessionFactoryBeanName("sqlSession");
+		return mapperConfigurer;
+	}
+
+	@Bean
+	public MapperConfigurer indvdlSchdulManageMapperConfigurer() {
+		MapperConfigurer mapperConfigurer = new MapperConfigurer();
+		mapperConfigurer.setBasePackage("egovframework.let.cop.smt.sim.service.impl");
+		mapperConfigurer.setSqlSessionFactoryBeanName("sqlSession");
+		return mapperConfigurer;
 	}
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageMapper.java
@@ -2,15 +2,13 @@ package egovframework.let.cop.com.service.impl;
 
 import java.util.List;
 
-import jakarta.annotation.Resource;
-
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.cop.com.service.BoardUseInf;
 import egovframework.let.cop.com.service.BoardUseInfVO;
 
 /**
- * 게시판 이용정보를 관리하기 위한 데이터 접근 클래스
+ * 게시판 이용정보를 관리하기 위한 매퍼 인터페이스
  * @author 공통서비스개발팀 이삼섭
  * @since 2009.04.02
  * @version 1.0
@@ -22,15 +20,11 @@ import egovframework.let.cop.com.service.BoardUseInfVO;
  *   수정일       수정자           수정내용
  *  -------     --------    ---------------------------
  *   2009.04.02  이삼섭          최초 생성
- *   2011.05.31  JJY           경량환경 커스터마이징버전 생성
  *
  * </pre>
  */
-@Repository("BBSUseInfoManageDAO")
-public class BBSUseInfoManageDAO {
-
-    @Resource(name = "BBSUseInfoManageMapper")
-    private BBSUseInfoManageMapper bbsUseInfoManageMapper;
+@EgovMapper
+public interface BBSUseInfoManageMapper {
 
     /**
      * 게시판 사용 정보를 삭제한다.
@@ -38,9 +32,7 @@ public class BBSUseInfoManageDAO {
      * @param bdUseInf
      * @throws Exception
      */
-    public void deleteBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-        bbsUseInfoManageMapper.deleteBBSUseInf(bdUseInf);
-    }
+    void deleteBBSUseInf(BoardUseInf bdUseInf) throws Exception;
 
     /**
      * 커뮤니티에 사용되는 게시판 사용정보 목록을 조회한다.
@@ -49,9 +41,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public List<BoardUseInf> selectBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInfByCmmnty(bdUseVO);
-    }
+    List<BoardUseInf> selectBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 동호회에 사용되는 게시판 사용정보 목록을 조회한다.
@@ -60,9 +50,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public List<BoardUseInf> selectBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInfByClub(bdUseVO);
-    }
+    List<BoardUseInf> selectBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 커뮤니티에 사용되는 모든 게시판 사용정보를 삭제한다.
@@ -70,9 +58,7 @@ public class BBSUseInfoManageDAO {
      * @param bdUseVO
      * @throws Exception
      */
-    public void deleteAllBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception {
-        bbsUseInfoManageMapper.deleteAllBBSUseInfByCmmnty(bdUseVO);
-    }
+    void deleteAllBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 동호회에 사용되는 모든 게시판 사용정보를 삭제한다.
@@ -80,9 +66,7 @@ public class BBSUseInfoManageDAO {
      * @param bdUseVO
      * @throws Exception
      */
-    public void deleteAllBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception {
-        bbsUseInfoManageMapper.deleteAllBBSUseInfByClub(bdUseVO);
-    }
+    void deleteAllBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 게시판 사용정보를 등록한다.
@@ -90,9 +74,7 @@ public class BBSUseInfoManageDAO {
      * @param bdUseInf
      * @throws Exception
      */
-    public void insertBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-        bbsUseInfoManageMapper.insertBBSUseInf(bdUseInf);
-    }
+    void insertBBSUseInf(BoardUseInf bdUseInf) throws Exception;
 
     /**
      * 게시판 사용정보 목록을 조회한다.
@@ -101,9 +83,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public List<BoardUseInfVO> selectBBSUseInfs(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInfs(bdUseVO);
-    }
+    List<BoardUseInfVO> selectBBSUseInfs(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 게시판 사용정보 목록 전체 건수를 조회한다.
@@ -112,9 +92,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public int selectBBSUseInfsCnt(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInfsCnt(bdUseVO);
-    }
+    int selectBBSUseInfsCnt(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 게시판 사용정보에 대한 상세정보를 조회한다.
@@ -123,9 +101,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public BoardUseInfVO selectBBSUseInf(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInf(bdUseVO);
-    }
+    BoardUseInfVO selectBBSUseInf(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 게시판 사용정보를 수정한다.
@@ -133,9 +109,7 @@ public class BBSUseInfoManageDAO {
      * @param bdUseInf
      * @throws Exception
      */
-    public void updateBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-        bbsUseInfoManageMapper.updateBBSUseInf(bdUseInf);
-    }
+    void updateBBSUseInf(BoardUseInf bdUseInf) throws Exception;
 
     /**
      * 게시판에 대한 사용정보를 삭제한다.
@@ -143,9 +117,7 @@ public class BBSUseInfoManageDAO {
      * @param bdUseInf
      * @throws Exception
      */
-    public void deleteBBSUseInfByBoardId(BoardUseInf bdUseInf) throws Exception {
-        bbsUseInfoManageMapper.deleteBBSUseInfByBoardId(bdUseInf);
-    }
+    void deleteBBSUseInfByBoardId(BoardUseInf bdUseInf) throws Exception;
 
     /**
      * 커뮤니티, 동호회에 사용되는 게시판 사용정보에 대한 목록을 조회한다.
@@ -154,9 +126,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public List<BoardUseInfVO> selectBBSUseInfsByTrget(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInfsByTrget(bdUseVO);
-    }
+    List<BoardUseInfVO> selectBBSUseInfsByTrget(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 커뮤니티, 동호회에 사용되는 게시판 사용정보에 대한 전체 건수를 조회한다.
@@ -165,9 +135,7 @@ public class BBSUseInfoManageDAO {
      * @return
      * @throws Exception
      */
-    public int selectBBSUseInfsCntByTrget(BoardUseInfVO bdUseVO) throws Exception {
-        return bbsUseInfoManageMapper.selectBBSUseInfsCntByTrget(bdUseVO);
-    }
+    int selectBBSUseInfsCntByTrget(BoardUseInfVO bdUseVO) throws Exception;
 
     /**
      * 커뮤니티, 동호회에 사용되는 게시판 사용정보를 수정한다.
@@ -175,7 +143,5 @@ public class BBSUseInfoManageDAO {
      * @param bdUseInf
      * @throws Exception
      */
-    public void updateBBSUseInfByTrget(BoardUseInf bdUseInf) throws Exception {
-        bbsUseInfoManageMapper.updateBBSUseInfByTrget(bdUseInf);
-    }
+    void updateBBSUseInfByTrget(BoardUseInf bdUseInf) throws Exception;
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageDAO.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.cop.com.service.impl;
 
 import java.util.List;
 
-import egovframework.let.cop.com.service.UserInfVO;
-
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
 
 import org.springframework.stereotype.Repository;
+
+import egovframework.let.cop.com.service.UserInfVO;
 
 /**
  * 협업 활용 사용자 정보 조회를 위한 데이터 접근 클래스
@@ -26,7 +26,10 @@ import org.springframework.stereotype.Repository;
  * </pre>
  */
 @Repository("EgovUserInfManageDAO")
-public class EgovUserInfManageDAO extends EgovAbstractMapper {
+public class EgovUserInfManageDAO {
+
+    @Resource(name = "EgovUserInfManageMapper")
+    private EgovUserInfManageMapper egovUserInfManageMapper;
 
     /**
      * 사용자 정보에 대한 목록을 조회한다.
@@ -35,9 +38,9 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @return
      * @throws Exception
      */
-	public List<UserInfVO> selectUserList(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectUserList", userVO);
-	}
+    public List<UserInfVO> selectUserList(UserInfVO userVO) throws Exception {
+        return egovUserInfManageMapper.selectUserList(userVO);
+    }
 
     /**
      * 사용자 정보에 대한 목록 전체 건수를 조회한다.
@@ -47,7 +50,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectUserListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectUserListCnt", userVO);
+        return egovUserInfManageMapper.selectUserListCnt(userVO);
     }
 
     /**
@@ -58,8 +61,8 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectCmmntyUserList(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectCmmntyUserList", userVO);
-	}
+        return egovUserInfManageMapper.selectCmmntyUserList(userVO);
+    }
 
     /**
      * 커뮤니티 사용자 목록에 대한 전체 건수를 조회한다.
@@ -69,7 +72,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectCmmntyUserListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectCmmntyUserListCnt", userVO);
+        return egovUserInfManageMapper.selectCmmntyUserListCnt(userVO);
     }
 
     /**
@@ -80,8 +83,8 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectCmmntyMngrList(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectCmmntyMngrList", userVO);
-	}
+        return egovUserInfManageMapper.selectCmmntyMngrList(userVO);
+    }
 
     /**
      * 커뮤니티 관리자 목록에 대한 전체 건수를 조회한다.
@@ -91,7 +94,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectCmmntyMngrListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectCmmntyMngrListCnt", userVO);
+        return egovUserInfManageMapper.selectCmmntyMngrListCnt(userVO);
     }
 
     /**
@@ -102,8 +105,8 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectClubUserList(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectClubUserList", userVO);
-	}
+        return egovUserInfManageMapper.selectClubUserList(userVO);
+    }
 
     /**
      * 동호회 사용자 목록에 대한 전체 건수를 조회한다.
@@ -113,7 +116,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectClubUserListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectClubUserListCnt", userVO);
+        return egovUserInfManageMapper.selectClubUserListCnt(userVO);
     }
 
     /**
@@ -124,8 +127,8 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectClubOprtrList(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectClubOprtrList", userVO);
-	}
+        return egovUserInfManageMapper.selectClubOprtrList(userVO);
+    }
 
     /**
      * 동호회 운영자 목록에 대한 전체 건수를 조회한다.
@@ -135,7 +138,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectClubOprtrListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectClubOprtrListCnt", userVO);
+        return egovUserInfManageMapper.selectClubOprtrListCnt(userVO);
     }
 
     /**
@@ -146,8 +149,8 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectAllClubUser(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectAllClubUser", userVO);
-	}
+        return egovUserInfManageMapper.selectAllClubUser(userVO);
+    }
 
     /**
      * 커뮤니티에 대한 모든 사용자 목록을 조회한다.
@@ -157,6 +160,6 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectAllCmmntyUser(UserInfVO userVO) throws Exception {
-		return selectList("EgovUserInfManageDAO.selectAllCmmntyUser", userVO);
-	}
+        return egovUserInfManageMapper.selectAllCmmntyUser(userVO);
+    }
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageMapper.java
@@ -1,0 +1,135 @@
+package egovframework.let.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.com.service.UserInfVO;
+
+/**
+ * 협업 활용 사용자 정보 조회를 위한 매퍼 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.04.06
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.06  이삼섭          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovUserInfManageMapper {
+
+    /**
+     * 사용자 정보에 대한 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectUserList(UserInfVO userVO) throws Exception;
+
+    /**
+     * 사용자 정보에 대한 목록 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    int selectUserListCnt(UserInfVO userVO) throws Exception;
+
+    /**
+     * 커뮤니티 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectCmmntyUserList(UserInfVO userVO) throws Exception;
+
+    /**
+     * 커뮤니티 사용자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    int selectCmmntyUserListCnt(UserInfVO userVO) throws Exception;
+
+    /**
+     * 커뮤니티 관리자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectCmmntyMngrList(UserInfVO userVO) throws Exception;
+
+    /**
+     * 커뮤니티 관리자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    int selectCmmntyMngrListCnt(UserInfVO userVO) throws Exception;
+
+    /**
+     * 동호회 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectClubUserList(UserInfVO userVO) throws Exception;
+
+    /**
+     * 동호회 사용자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    int selectClubUserListCnt(UserInfVO userVO) throws Exception;
+
+    /**
+     * 동호회 운영자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectClubOprtrList(UserInfVO userVO) throws Exception;
+
+    /**
+     * 동호회 운영자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    int selectClubOprtrListCnt(UserInfVO userVO) throws Exception;
+
+    /**
+     * 동호회에 대한 모든 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectAllClubUser(UserInfVO userVO) throws Exception;
+
+    /**
+     * 커뮤니티에 대한 모든 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     * @throws Exception
+     */
+    List<UserInfVO> selectAllCmmntyUser(UserInfVO userVO) throws Exception;
+}

--- a/src/main/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageDao.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageDao.java
@@ -3,12 +3,12 @@ package egovframework.let.cop.smt.sim.service.impl;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
-
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 
 /**
  * 일정관리를 처리하는 Dao Class 구현
@@ -24,7 +24,10 @@ import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
  * @created 09-6-2011 오전 10:08:07
  */
 @Repository("indvdlSchdulManageDao")
-public class IndvdlSchdulManageDao extends EgovAbstractMapper {
+public class IndvdlSchdulManageDao {
+
+    @Resource(name = "IndvdlSchdulManageMapper")
+    private IndvdlSchdulManageMapper indvdlSchdulManageMapper;
 
 	/**
 	 * 메인페이지/일정관리조회 목록을 Map(map)형식으로 조회한다.
@@ -33,7 +36,7 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public List<?> selectIndvdlSchdulManageMainList(Map<?, ?> map) throws Exception {
-		return selectList("IndvdlSchdulManage.selectIndvdlSchdulManageMainList", map);
+		return indvdlSchdulManageMapper.selectIndvdlSchdulManageMainList(map);
 	}
 
 	/**
@@ -43,7 +46,7 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public List<?> selectIndvdlSchdulManageRetrieve(Map<?, ?> map) throws Exception {
-		return selectList("IndvdlSchdulManage.selectIndvdlSchdulManageRetrieve", map);
+		return indvdlSchdulManageMapper.selectIndvdlSchdulManageRetrieve(map);
 	}
 
 	/**
@@ -54,8 +57,7 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 */
 	public IndvdlSchdulManageVO selectIndvdlSchdulManageDetailVO(IndvdlSchdulManageVO indvdlSchdulManageVO)
 		throws Exception {
-		return (IndvdlSchdulManageVO)selectOne("IndvdlSchdulManage.selectIndvdlSchdulManageDetailVO",
-			indvdlSchdulManageVO);
+		return indvdlSchdulManageMapper.selectIndvdlSchdulManageDetailVO(indvdlSchdulManageVO);
 	}
 
 	/**
@@ -65,20 +67,17 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public List<?> selectIndvdlSchdulManageList(ComDefaultVO searchVO) throws Exception {
-		return selectList("IndvdlSchdulManage.selectIndvdlSchdulManage", searchVO);
+		return indvdlSchdulManageMapper.selectIndvdlSchdulManage(searchVO);
 	}
 
 	/**
 	 * 일정를(을) 상세조회 한다.
 	 * @param indvdlSchdulManageVO - 일정 정보 담김 VO
-	 * @return List
+	 * @return IndvdlSchdulManageVO
 	 * @throws Exception
 	 */
-	//	public List<?> selectIndvdlSchdulManageDetail(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
-	//		return list("IndvdlSchdulManage.selectIndvdlSchdulManageDetail", indvdlSchdulManageVO);
-	//}
 	public IndvdlSchdulManageVO selectIndvdlSchdulManageDetail(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
-		return selectOne("IndvdlSchdulManage.selectIndvdlSchdulManageDetailVO", indvdlSchdulManageVO);
+		return indvdlSchdulManageMapper.selectIndvdlSchdulManageDetailVO(indvdlSchdulManageVO);
 	}
 
 	/**
@@ -88,16 +87,16 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public int selectIndvdlSchdulManageListCnt(ComDefaultVO searchVO) throws Exception {
-		return (Integer)selectOne("IndvdlSchdulManage.selectIndvdlSchdulManageCnt", searchVO);
+		return indvdlSchdulManageMapper.selectIndvdlSchdulManageCnt(searchVO);
 	}
 
 	/**
 	 * 일정를(을) 등록한다.
-	 * @param qindvdlSchdulManageVO - 일정 정보 담김 VO
+	 * @param indvdlSchdulManageVO - 일정 정보 담김 VO
 	 * @throws Exception
 	 */
 	public void insertIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
-		insert("IndvdlSchdulManage.insertIndvdlSchdulManage", indvdlSchdulManageVO);
+		indvdlSchdulManageMapper.insertIndvdlSchdulManage(indvdlSchdulManageVO);
 	}
 
 	/**
@@ -106,7 +105,7 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void updateIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
-		insert("IndvdlSchdulManage.updateIndvdlSchdulManage", indvdlSchdulManageVO);
+		indvdlSchdulManageMapper.updateIndvdlSchdulManage(indvdlSchdulManageVO);
 	}
 
 	/**
@@ -115,9 +114,6 @@ public class IndvdlSchdulManageDao extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
-		// 일지 삭제
-		//delete("IndvdlSchdulManage.deleteDiaryManage", indvdlSchdulManageVO);
-		// 일정관리 삭제
-		delete("IndvdlSchdulManage.deleteIndvdlSchdulManage", indvdlSchdulManageVO);
+		indvdlSchdulManageMapper.deleteIndvdlSchdulManage(indvdlSchdulManageVO);
 	}
 }

--- a/src/main/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageMapper.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageMapper.java
@@ -1,0 +1,97 @@
+package egovframework.let.cop.smt.sim.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+/**
+ * 일정관리를 처리하는 매퍼 인터페이스
+ * @since 2009.04.10
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  장동한          최초 생성
+ *
+ * </pre>
+ * @author 조재영
+ * @version 1.0
+ */
+@EgovMapper
+public interface IndvdlSchdulManageMapper {
+
+    /**
+     * 메인페이지/일정관리조회 목록을 Map 형식으로 조회한다.
+     *
+     * @param map - 조회할 정보가 담긴 Map
+     * @return List
+     * @throws Exception
+     */
+    List<?> selectIndvdlSchdulManageMainList(Map<?, ?> map) throws Exception;
+
+    /**
+     * 일정 목록을 Map 형식으로 조회한다.
+     *
+     * @param map - 조회할 정보가 담긴 Map
+     * @return List
+     * @throws Exception
+     */
+    List<?> selectIndvdlSchdulManageRetrieve(Map<?, ?> map) throws Exception;
+
+    /**
+     * 일정 목록을 VO 형식으로 조회한다.
+     *
+     * @param indvdlSchdulManageVO - 조회할 정보가 담긴 VO
+     * @return IndvdlSchdulManageVO
+     * @throws Exception
+     */
+    IndvdlSchdulManageVO selectIndvdlSchdulManageDetailVO(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+    /**
+     * 일정 목록을 조회한다.
+     *
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     * @throws Exception
+     */
+    List<?> selectIndvdlSchdulManage(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 일정 목록 전체 건수를 조회한다.
+     *
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectIndvdlSchdulManageCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 일정를(을) 등록한다.
+     *
+     * @param indvdlSchdulManageVO - 일정 정보 담김 VO
+     * @throws Exception
+     */
+    void insertIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+    /**
+     * 일정를(을) 수정한다.
+     *
+     * @param indvdlSchdulManageVO - 일정 정보 담김 VO
+     * @throws Exception
+     */
+    void updateIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+    /**
+     * 일정를(을) 삭제한다.
+     *
+     * @param indvdlSchdulManageVO - 일정 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+}

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.EgovUserInfManageMapper">
 
 
 	<resultMap id="UserInfs" type="egovframework.let.cop.com.service.UserInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.EgovUserInfManageMapper">
 
 
 	<resultMap id="UserInfs" type="egovframework.let.cop.com.service.UserInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.EgovUserInfManageMapper">
 
 
 	<resultMap id="UserInfs" type="egovframework.let.cop.com.service.UserInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.EgovUserInfManageMapper">
 
 
 	<resultMap id="UserInfs" type="egovframework.let.cop.com.service.UserInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.EgovUserInfManageMapper">
 
 
 	<resultMap id="UserInfs" type="egovframework.let.cop.com.service.UserInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovUserInf_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.EgovUserInfManageMapper">
 
 
 	<resultMap id="UserInfs" type="egovframework.let.cop.com.service.UserInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">


### PR DESCRIPTION
cop/com, cop/smt/sim 모듈의 DAO 클래스 3개를 EgovAbstractMapper 상속 방식에서 @EgovMapper 어노테이션 인터페이스 위임 방식으로 전환합니다.

## 변경 내용

**신규 Mapper 인터페이스 추가**
- `BBSUseInfoManageMapper` (@EgovMapper) — 게시판 이용정보 관리
- `EgovUserInfManageMapper` (@EgovMapper) — 협업 사용자 정보 조회
- `IndvdlSchdulManageMapper` (@EgovMapper) — 개인 일정 관리

**DAO 전환**
- `BBSUseInfoManageDAO`: EgovAbstractMapper 상속 제거 → BBSUseInfoManageMapper 위임
- `EgovUserInfManageDAO`: EgovAbstractMapper 상속 제거 → EgovUserInfManageMapper 위임
- `IndvdlSchdulManageDao`: EgovAbstractMapper 상속 제거 → IndvdlSchdulManageMapper 위임

**XML namespace 변경 (6개 DB 방언 × 3)**
- `EgovBBSUse_SQL_*.xml`: `BBSUseInfoManageDAO` → `egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper`
- `EgovUserInf_SQL_*.xml`: `EgovUserInfManageDAO` → `egovframework.let.cop.com.service.impl.EgovUserInfManageMapper`
- `EgovIndvdlSchdulManage_SQL_*.xml`: `IndvdlSchdulManage` → `egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper`

**설정 추가**
- `EgovConfigAppMapper`: `bbsUseInfoManageMapperConfigurer`, `indvdlSchdulManageMapperConfigurer` 빈 등록

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 DAO 메서드명 및 ServiceImpl 변경 없음
- [x] 빌드(`mvn compile`) 오류 없음 확인
- [x] 기존 동작에 영향 없음
