### PR TITLE
[refactor] StplatVO·UserDefaultVO·EgovMainContentsVO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/let/main/service/EgovMainContentsVO.java
+++ b/src/main/java/egovframework/let/main/service/EgovMainContentsVO.java
@@ -2,6 +2,9 @@ package egovframework.let.main.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 템플릿 메인화면 작업 List 항목 VO(Sample 소스)
  * @author 실행환경 개발팀 JJY
@@ -11,13 +14,16 @@ import java.io.Serializable;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2011.08.31  JJY            최초 생성
+ *   2025.06.05  dasomell       Lombok @Getter/@Setter 적용
  *
  * </pre>
  */
+@Getter
+@Setter
 public class EgovMainContentsVO implements Serializable {
 
 	/**
@@ -34,26 +40,11 @@ public class EgovMainContentsVO implements Serializable {
 	private String workItemURL;
 
 	/**
-	 * getItemCount 항목 개수 getter
-	 * @return
+	 * 작업항목 개수 (기본값 0)
+	 * @return 항목 개수
 	 */
-	public int getItemCount(){
+	public int getItemCount() {
 		return 0;
 	}
 
-	/**
-	 * getWorkItemName To-Do List 항목 명 getter
-	 * @return To-Do List 항목 명
-	 */
-	public String getWorkItemName(){
-		return workItemName;
-	}
-
-	/**
-	 * getWorkItemURL 업무화면 URL getter
-	 * @return 업무화면 URL
-	 */
-	public String getWorkItemURL(){
-		return workItemURL;
-	}
 }

--- a/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
@@ -2,10 +2,9 @@ package egovframework.let.uss.umt.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 /**
  * 가입약관VO클래스로서가입약관확인시 비지니스로직 처리용 항목을 구성한다.
@@ -26,6 +25,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@ToString
 public class StplatVO implements Serializable {
 	/**
 	 * serialVersionUID
@@ -40,12 +40,5 @@ public class StplatVO implements Serializable {
 
     /** 정보동의안내*/
     private String infoProvdAgeCn;
-
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
 
 }

--- a/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
@@ -2,10 +2,9 @@ package egovframework.let.uss.umt.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 /**
  * 사용자정보 VO클래스로서일반회원, 기업회원, 업무사용자의  비지니스로직 처리시 기타조건성 항목을 구성한다.
@@ -26,6 +25,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@ToString
 public class UserDefaultVO implements Serializable {
 
 	/**
@@ -63,11 +63,5 @@ public class UserDefaultVO implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
 
 }


### PR DESCRIPTION
## 변경 사유

수동으로 작성된 boilerplate getter/setter/toString 코드를 Lombok 어노테이션으로 대체하여 코드 가독성과 유지보수성을 개선한다. 이미 pom.xml에 Lombok 의존성이 선언되어 있으므로 별도 의존성 추가는 불필요하다.

## 변경 내용

- `StplatVO`: 수동 getter/setter 제거 → `@Getter`/`@Setter` 적용. `ToStringBuilder.reflectionToString()` 위임 `toString()` 제거 → `@ToString` 적용. `commons-lang3` import 정리.
- `UserDefaultVO`: 동일하게 `@Getter`/`@Setter`/`@ToString` 적용 및 `ToStringBuilder` import 제거.
- `EgovMainContentsVO`: `@Getter`/`@Setter` 적용. `getItemCount()`는 항상 0을 반환하는 커스텀 로직이므로 그대로 유지.

## 영향 범위

- 기존 동작 변화 없음 (Lombok이 컴파일 시점에 동일한 바이트코드를 생성)
- 3개 VO 파일만 변경, 다른 모듈 영향 없음

## 확인 사항

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] Lombok 의존성은 기존 pom.xml에 이미 포함되어 있음