### PR TITLE
test: 유틸리티 클래스 7종 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -1,0 +1,140 @@
+package egovframework.com.cmm;
+
+import egovframework.com.cmm.service.ResultVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovWebUtilTest {
+
+    @DisplayName("handleAuthError 호출 시, 코드와 메시지가 담긴 ResultVO를 반환한다.")
+    @Test
+    void testHandleAuthError() {
+        // given
+        int code = 401;
+        String msg = "인증 실패";
+
+        // when
+        ResultVO result = EgovWebUtil.handleAuthError(code, msg);
+
+        // then
+        assertEquals(code, result.getResultCode());
+        assertEquals(msg, result.getResultMessage());
+    }
+
+    @DisplayName("clearXSSMinimum 호출 시, null 또는 빈 문자열이면 빈 문자열을 반환한다.")
+    @Test
+    void testClearXSSMinimumWithNullOrEmpty() {
+        assertEquals("", EgovWebUtil.clearXSSMinimum(null));
+        assertEquals("", EgovWebUtil.clearXSSMinimum(""));
+        assertEquals("", EgovWebUtil.clearXSSMinimum("  "));
+    }
+
+    @DisplayName("clearXSSMinimum 호출 시, 특수문자를 HTML 엔티티로 치환한다.")
+    @Test
+    void testClearXSSMinimumEscapesSpecialChars() {
+        // given
+        String value = "<script>alert('x&y\".')</script>";
+
+        // when
+        String result = EgovWebUtil.clearXSSMinimum(value);
+
+        // then
+        assertEquals("&lt;script&gt;alert(&#39;x&amp;y&#34;&#46;&#39;)&lt;/script&gt;", result);
+    }
+
+    @DisplayName("clearXSSMaximum 호출 시, 홑 퍼센트 기호를 엔티티로 치환하고 특수문자를 치환한다.")
+    @Test
+    void testClearXSSMaximumEscapesPercentAndTags() {
+        // given
+        String value = "100% off <script>";
+
+        // when
+        String result = EgovWebUtil.clearXSSMaximum(value);
+
+        // then
+        assertEquals("100&#37; off &lt;script&gt;", result);
+    }
+
+    @DisplayName("filePathBlackList(value) 호출 시, null 또는 빈 문자열이면 빈 문자열을 반환한다.")
+    @Test
+    void testFilePathBlackListWithNullOrEmpty() {
+        assertEquals("", EgovWebUtil.filePathBlackList((String) null));
+        assertEquals("", EgovWebUtil.filePathBlackList(""));
+    }
+
+    @DisplayName("filePathBlackList(value) 호출 시, 상위 디렉토리 이동 패턴(..)을 제거한다.")
+    @Test
+    void testFilePathBlackListRemovesDotDot() {
+        assertEquals("//etc/passwd", EgovWebUtil.filePathBlackList("../../etc/passwd"));
+    }
+
+    @DisplayName("filePathBlackList(value, basePath) 호출 시, basePath가 비어있으면 SecurityException이 발생한다.")
+    @Test
+    void testFilePathBlackListWithEmptyBasePathThrows() {
+        assertThrows(SecurityException.class, () -> EgovWebUtil.filePathBlackList("file.txt", ""));
+        assertThrows(SecurityException.class, () -> EgovWebUtil.filePathBlackList("file.txt", null));
+    }
+
+    @DisplayName("filePathBlackList(value, basePath) 호출 시, basePath가 루트 경로이면 SecurityException이 발생한다.")
+    @Test
+    void testFilePathBlackListWithRootBasePathThrows() {
+        assertThrows(SecurityException.class, () -> EgovWebUtil.filePathBlackList("file.txt", "/"));
+    }
+
+    @DisplayName("filePathBlackList(value, basePath) 호출 시, basePath와 결합된 경로에서 상위 디렉토리 이동 패턴을 제거한다.")
+    @Test
+    void testFilePathBlackListWithBasePath() {
+        assertEquals("/data/uploads//file.txt", EgovWebUtil.filePathBlackList("../file.txt", "/data/uploads/"));
+    }
+
+    @DisplayName("filePathReplaceAll 호출 시, 경로 구분자와 상위 디렉토리 이동 패턴 및 &을 제거한다.")
+    @Test
+    void testFilePathReplaceAll() {
+        assertEquals("", EgovWebUtil.filePathReplaceAll(null));
+        assertEquals("", EgovWebUtil.filePathReplaceAll(""));
+        assertEquals("etcpasswd", EgovWebUtil.filePathReplaceAll("../etc/passwd&"));
+    }
+
+    @DisplayName("fileInjectPathReplaceAll 호출 시, 경로 구분자와 &을 제거한다.")
+    @Test
+    void testFileInjectPathReplaceAll() {
+        assertEquals("", EgovWebUtil.fileInjectPathReplaceAll(null));
+        assertEquals("", EgovWebUtil.fileInjectPathReplaceAll(""));
+        assertEquals("etcpasswd", EgovWebUtil.fileInjectPathReplaceAll("etc/passwd&"));
+    }
+
+    @DisplayName("filePathWhiteList 호출 시, 입력값을 그대로 반환한다.")
+    @Test
+    void testFilePathWhiteList() {
+        assertEquals("value", EgovWebUtil.filePathWhiteList("value"));
+        assertNull(EgovWebUtil.filePathWhiteList(null));
+    }
+
+    @DisplayName("isIPAddress 호출 시, IPv4 형식 문자열만 true를 반환한다.")
+    @Test
+    void testIsIPAddress() {
+        assertTrue(EgovWebUtil.isIPAddress("192.168.0.1"));
+        assertFalse(EgovWebUtil.isIPAddress("not-an-ip"));
+        assertFalse(EgovWebUtil.isIPAddress("localhost"));
+    }
+
+    @DisplayName("removeCRLF 호출 시, 캐리지리턴과 개행문자를 제거한다.")
+    @Test
+    void testRemoveCRLF() {
+        assertEquals("abcdef", EgovWebUtil.removeCRLF("ab\rcd\nef"));
+    }
+
+    @DisplayName("removeSQLInjectionRisk 호출 시, SQL 인젝션 위험 문자를 제거한다.")
+    @Test
+    void testRemoveSQLInjectionRisk() {
+        assertEquals("abcSELECTFROM", EgovWebUtil.removeSQLInjectionRisk("a b*c; SELECT % FROM- +,"));
+    }
+
+    @DisplayName("removeOSCmdRisk 호출 시, OS 명령어 인젝션 위험 문자를 제거한다.")
+    @Test
+    void testRemoveOSCmdRisk() {
+        assertEquals("abcls", EgovWebUtil.removeOSCmdRisk("a b*c; ls |"));
+    }
+}

--- a/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
@@ -1,0 +1,139 @@
+package egovframework.com.cmm.service;
+
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EgovFileMngUtilTest {
+
+    private EgovFileMngUtil egovFileMngUtil;
+    private EgovPropertyService propertyService;
+    private EgovIdGnrService idgenService;
+
+    @BeforeEach
+    void setUp() {
+        egovFileMngUtil = new EgovFileMngUtil();
+        propertyService = mock(EgovPropertyService.class);
+        idgenService = mock(EgovIdGnrService.class);
+
+        ReflectionTestUtils.setField(egovFileMngUtil, "allowedExtensionsRaw", ".gif.jpg.jpeg.png.xls.xlsx");
+        ReflectionTestUtils.setField(egovFileMngUtil, "propertyService", propertyService);
+        ReflectionTestUtils.setField(egovFileMngUtil, "idgenService", idgenService);
+    }
+
+    @DisplayName("parseFileInf 호출 시, 허용된 확장자의 파일이면 FileVO 목록을 반환한다.")
+    @Test
+    void testParseFileInfWithAllowedExtension(@TempDir Path tempDir) throws Exception {
+        // given
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+        when(idgenService.getNextStringId()).thenReturn("ATCH0001");
+
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("photo.png");
+        when(multipartFile.getSize()).thenReturn(100L);
+
+        Map<String, MultipartFile> files = new LinkedHashMap<>();
+        files.put("file", multipartFile);
+
+        // when
+        List<FileVO> result = egovFileMngUtil.parseFileInf(files, "KEY", 1, "", "");
+
+        // then
+        assertEquals(1, result.size());
+        FileVO fileVO = result.get(0);
+        assertEquals("png", fileVO.getFileExtsn());
+        assertEquals(tempDir.toString(), fileVO.getFileStreCours());
+        assertEquals("100", fileVO.getFileMg());
+        assertEquals("photo.png", fileVO.getOrignlFileNm());
+        assertEquals("ATCH0001", fileVO.getAtchFileId());
+        assertEquals("1", fileVO.getFileSn());
+        verify(multipartFile, times(1)).transferTo(any(java.io.File.class));
+    }
+
+    @DisplayName("parseFileInf 호출 시, 허용되지 않은 확장자면 EgovBizException이 발생한다.")
+    @Test
+    void testParseFileInfWithDisallowedExtensionThrows(@TempDir Path tempDir) {
+        // given
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("malware.exe");
+
+        Map<String, MultipartFile> files = new LinkedHashMap<>();
+        files.put("file", multipartFile);
+
+        // when / then
+        assertThrows(EgovBizException.class, () -> egovFileMngUtil.parseFileInf(files, "KEY", 1, "", ""));
+    }
+
+    @DisplayName("parseFileInf 호출 시, 최대 허용 크기를 초과하면 EgovBizException이 발생한다.")
+    @Test
+    void testParseFileInfWithOversizedFileThrows(@TempDir Path tempDir) {
+        // given
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("big.png");
+        when(multipartFile.getSize()).thenReturn(11L * 1024 * 1024);
+
+        Map<String, MultipartFile> files = new LinkedHashMap<>();
+        files.put("file", multipartFile);
+
+        // when / then
+        assertThrows(EgovBizException.class, () -> egovFileMngUtil.parseFileInf(files, "KEY", 1, "", ""));
+    }
+
+    @DisplayName("parseFileInf 호출 시, 확장자가 없는 파일이면 EgovBizException이 발생한다.")
+    @Test
+    void testParseFileInfWithNoExtensionThrows(@TempDir Path tempDir) {
+        // given
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("noextension");
+
+        Map<String, MultipartFile> files = new LinkedHashMap<>();
+        files.put("file", multipartFile);
+
+        // when / then
+        assertThrows(EgovBizException.class, () -> egovFileMngUtil.parseFileInf(files, "KEY", 1, "", ""));
+    }
+
+    @DisplayName("parseFileInf 호출 시, 원 파일명이 빈 파일은 건너뛴다.")
+    @Test
+    void testParseFileInfSkipsFileWithoutOriginalName(@TempDir Path tempDir) throws Exception {
+        // given
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("");
+
+        Map<String, MultipartFile> files = new LinkedHashMap<>();
+        files.put("file", multipartFile);
+
+        // when
+        List<FileVO> result = egovFileMngUtil.parseFileInf(files, "KEY", 1, "", "");
+
+        // then
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovDateUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovDateUtilTest.java
@@ -1,0 +1,234 @@
+package egovframework.let.utl.fcc.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovDateUtilTest {
+
+    @DisplayName("addYearMonthDay 호출 시, 년/월/일을 가감한 날짜를 반환한다.")
+    @Test
+    void testAddYearMonthDay() {
+        assertEquals("19810916", EgovDateUtil.addYearMonthDay("19810828", 0, 0, 19));
+        assertEquals("20060218", EgovDateUtil.addYearMonthDay("20060228", 0, 0, -10));
+        assertEquals("20060310", EgovDateUtil.addYearMonthDay("20060228", 0, 0, 10));
+        assertEquals("20060401", EgovDateUtil.addYearMonthDay("20060228", 0, 0, 32));
+        assertEquals("20050228", EgovDateUtil.addYearMonthDay("20050331", 0, -1, 0));
+        assertEquals("20050531", EgovDateUtil.addYearMonthDay("20050301", 0, 2, 30));
+        assertEquals("20060531", EgovDateUtil.addYearMonthDay("20050301", 1, 2, 30));
+    }
+
+    @DisplayName("addYearMonthDay 호출 시, 잘못된 날짜 포맷이면 IllegalArgumentException이 발생한다.")
+    @Test
+    void testAddYearMonthDayWithInvalidFormatThrows() {
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.addYearMonthDay("2006", 0, 0, 1));
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.addYearMonthDay(null, 0, 0, 1));
+    }
+
+    @DisplayName("addYear 호출 시, 년을 가감한 날짜를 반환한다.")
+    @Test
+    void testAddYear() {
+        assertEquals("20620201", EgovDateUtil.addYear("20000201", 62));
+        assertEquals("20000201", EgovDateUtil.addYear("20620201", -62));
+        assertEquals("20060228", EgovDateUtil.addYear("20040229", 2));
+    }
+
+    @DisplayName("addMonth 호출 시, 월을 가감한 날짜를 반환한다.")
+    @Test
+    void testAddMonth() {
+        assertEquals("20020201", EgovDateUtil.addMonth("20010201", 12));
+        assertEquals("19810228", EgovDateUtil.addMonth("19800229", 12));
+        assertEquals("20060228", EgovDateUtil.addMonth("20060131", 1));
+    }
+
+    @DisplayName("addDay 호출 시, 일을 가감한 날짜를 반환한다.")
+    @Test
+    void testAddDay() {
+        assertEquals("20000201", EgovDateUtil.addDay("19991201", 62));
+        assertEquals("19991201", EgovDateUtil.addDay("20000201", -62));
+        assertEquals("20050903", EgovDateUtil.addDay("20050831", 3));
+    }
+
+    @DisplayName("getDaysDiff 호출 시, 두 날짜 사이의 일수 차이를 반환한다.")
+    @Test
+    void testGetDaysDiff() {
+        assertEquals(10, EgovDateUtil.getDaysDiff("20060228", "20060310"));
+        assertEquals(365, EgovDateUtil.getDaysDiff("20060101", "20070101"));
+        assertEquals(-28, EgovDateUtil.getDaysDiff("19990228", "19990131"));
+        assertEquals(0, EgovDateUtil.getDaysDiff("20060801", "20060801"));
+    }
+
+    @DisplayName("checkDate(String) 호출 시, 유효한 8자리 날짜 문자열이면 true를 반환한다.")
+    @Test
+    void testCheckDateString() {
+        assertTrue(EgovDateUtil.checkDate("20060228"));
+        assertFalse(EgovDateUtil.checkDate("20061131"));
+    }
+
+    @DisplayName("checkDate(year, month, day) 호출 시, 유효한 날짜인지 확인한다.")
+    @Test
+    void testCheckDateYearMonthDay() {
+        assertTrue(EgovDateUtil.checkDate("2006", "02", "28"));
+        assertFalse(EgovDateUtil.checkDate("2006", "13", "31"));
+        assertFalse(EgovDateUtil.checkDate("2006", "11", "31"));
+    }
+
+    @DisplayName("convertDate(source, from, to, tz) 호출 시, 날짜 포맷을 변환한다.")
+    @Test
+    void testConvertDateFormat() {
+        assertEquals("2021-01-02 03:04:05", EgovDateUtil.convertDate("20210102030405", "yyyyMMddHHmmss", "yyyy-MM-dd HH:mm:ss", ""));
+        assertEquals("", EgovDateUtil.convertDate("", "yyyyMMdd", "yyyy-MM-dd", ""));
+    }
+
+    @DisplayName("formatDate 호출 시, 지정한 구분자로 날짜 문자열을 나눈다.")
+    @Test
+    void testFormatDate() {
+        assertEquals("2003.04.05", EgovDateUtil.formatDate("20030405", "."));
+        assertEquals("2004/01/01", EgovDateUtil.formatDate("20040101", "/"));
+        assertEquals("", EgovDateUtil.formatDate("00000101", "/"));
+    }
+
+    @DisplayName("formatDate 호출 시, 8자리 또는 10자리가 아닌 날짜 문자열이면 IllegalArgumentException이 발생한다.")
+    @Test
+    void testFormatDateWithInvalidLengthThrows() {
+        // validChkDate가 선행 검증하므로 6자리 등 그 외 길이는 내부 분기와 무관하게 예외가 발생한다.
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.formatDate("200304", "."));
+    }
+
+    @DisplayName("formatTime 호출 시, validChkTime을 통과하지 못하는 길이의 입력은 예외가 발생한다.")
+    @Test
+    void testFormatTimeWithInvalidLengthThrows() {
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.formatTime("151241", "/"));
+    }
+
+    @DisplayName("isLeapYear 호출 시, 윤년이면 false, 평년이면 true를 반환한다(구현 그대로 검증).")
+    @Test
+    void testIsLeapYear() {
+        // 구현상 이름과 반대로 윤년일 때 false, 평년일 때 true를 반환한다.
+        assertFalse(EgovDateUtil.isLeapYear(2004));
+        assertFalse(EgovDateUtil.isLeapYear(2000));
+        assertTrue(EgovDateUtil.isLeapYear(2005));
+        assertTrue(EgovDateUtil.isLeapYear(2006));
+        assertTrue(EgovDateUtil.isLeapYear(1900));
+    }
+
+    @DisplayName("getToday / getCurrentDate(\"\") 호출 시, 8자리 숫자 날짜 문자열을 반환한다.")
+    @Test
+    void testGetTodayAndCurrentDate() {
+        String today = EgovDateUtil.getToday();
+        assertEquals(8, today.length());
+        assertTrue(today.matches("\\d{8}"));
+
+        String currentDate = EgovDateUtil.getCurrentDate("");
+        assertEquals(today.length(), currentDate.length());
+        assertTrue(currentDate.matches("\\d{8}"));
+    }
+
+    @DisplayName("getCurrentDate(dateType) 호출 시, dateType이 비어있지 않으면 내부 convertDate 오버로드 혼선으로 예외가 발생한다.")
+    @Test
+    void testGetCurrentDateWithFormatThrows() {
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getCurrentDate("yyyy-MM-dd"));
+    }
+
+    @DisplayName("convertDate(date, time, formatStr) 호출 시, 지정한 포맷으로 조합된 날짜/시간 문자열을 반환한다.")
+    @Test
+    void testConvertDateTimeFormat() {
+        assertEquals("2021-01-02 03:04", EgovDateUtil.convertDate("20210102", "0304", "yyyy-MM-dd HH:mm"));
+    }
+
+    @DisplayName("getRandomDate 호출 시, 지정한 두 날짜 사이의 임의 날짜를 반환한다.")
+    @Test
+    void testGetRandomDate() {
+        for (int i = 0; i < 20; i++) {
+            String random = EgovDateUtil.getRandomDate("20200101", "20200110");
+            assertEquals(8, random.length());
+            assertTrue(random.compareTo("20200101") >= 0 && random.compareTo("20200110") <= 0);
+        }
+    }
+
+    @DisplayName("getRandomDate 호출 시, 종료일이 시작일보다 과거이면 IllegalArgumentException이 발생한다.")
+    @Test
+    void testGetRandomDateWithInvalidRangeThrows() {
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getRandomDate("20200110", "20200101"));
+    }
+
+    @DisplayName("toLunar 호출 시, 8자리 음력 날짜와 윤달 여부를 반환한다.")
+    @Test
+    void testToLunar() {
+        Map<String, String> result = EgovDateUtil.toLunar("20230101");
+        assertEquals(8, result.get("day").length());
+        assertTrue(result.get("leap").equals("0") || result.get("leap").equals("1"));
+    }
+
+    @DisplayName("toLunar 호출 시, 8자리가 아닌 날짜 문자열이면 빈 결과를 반환한다.")
+    @Test
+    void testToLunarWithShortInput() {
+        Map<String, String> result = EgovDateUtil.toLunar("2023010112");
+        assertEquals("", result.get("day"));
+        assertEquals("0", result.get("leap"));
+    }
+
+    @DisplayName("toSolar 호출 시, 음력 날짜를 양력 날짜로 변환한다.")
+    @Test
+    void testToSolar() {
+        String lunar = EgovDateUtil.toLunar("20230101").get("day");
+        String solar = EgovDateUtil.toSolar(lunar, 0);
+        assertEquals("20230101", solar);
+    }
+
+    @DisplayName("convertWeek 호출 시, 영문 요일명을 국문 요일명으로 변환한다.")
+    @Test
+    void testConvertWeek() {
+        assertEquals("일요일", EgovDateUtil.convertWeek("SUN"));
+        assertEquals("월요일", EgovDateUtil.convertWeek("MON"));
+        assertEquals("토요일", EgovDateUtil.convertWeek("SAT"));
+        assertNull(EgovDateUtil.convertWeek("XXX"));
+    }
+
+    @DisplayName("validDate(sDate) 호출 시, 유효한 날짜인지 확인한다.")
+    @Test
+    void testValidDate() {
+        assertTrue(EgovDateUtil.validDate("20230101"));
+        assertFalse(EgovDateUtil.validDate("20230230"));
+    }
+
+    @DisplayName("validTime 호출 시, 유효한 시간인지 확인한다.")
+    @Test
+    void testValidTime() {
+        assertTrue(EgovDateUtil.validTime("1230"));
+        assertFalse(EgovDateUtil.validTime("2530"));
+    }
+
+    @DisplayName("addYMDtoWeek 호출 시, 가감된 날짜의 요일(영문 약어)을 반환한다.")
+    @Test
+    void testAddYMDtoWeek() {
+        // 2023-01-01은 일요일(Sun) 이었으므로 1일을 더하면 월요일(Mon)이 된다.
+        assertEquals("Mon", EgovDateUtil.addYMDtoWeek("20230101", 0, 0, 1));
+    }
+
+    @DisplayName("datetoInt / timetoInt 호출 시, 날짜/시간을 int 형으로 변환한다.")
+    @Test
+    void testDatetoIntAndTimetoInt() {
+        assertEquals(20230101, EgovDateUtil.datetoInt("20230101"));
+        assertEquals(1230, EgovDateUtil.timetoInt("1230"));
+    }
+
+    @DisplayName("validChkDate 호출 시, 8자리 문자열은 그대로, 10자리(하이픈 포함) 문자열은 하이픈을 제거하여 반환한다.")
+    @Test
+    void testValidChkDate() {
+        assertEquals("20230101", EgovDateUtil.validChkDate("20230101"));
+        assertEquals("20230101", EgovDateUtil.validChkDate("2023-01-01"));
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkDate("202301"));
+    }
+
+    @DisplayName("validChkTime 호출 시, 4자리 문자열은 그대로, 콜론 포함 5자리 문자열은 콜론을 제거하여 반환한다.")
+    @Test
+    void testValidChkTime() {
+        assertEquals("1230", EgovDateUtil.validChkTime("1230"));
+        assertEquals("1230", EgovDateUtil.validChkTime("12:30"));
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("123"));
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovFileUploadUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovFileUploadUtilTest.java
@@ -1,0 +1,44 @@
+package egovframework.let.utl.fcc.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EgovFileUploadUtilTest {
+
+    @DisplayName("getFileExtension 호출 시, 파일명에서 확장자를 추출하며 null이면 빈 문자열을 반환한다.")
+    @Test
+    void testGetFileExtension() {
+        assertEquals("", EgovFileUploadUtil.getFileExtension(null));
+        assertEquals("txt", EgovFileUploadUtil.getFileExtension("document.txt"));
+        assertEquals("gz", EgovFileUploadUtil.getFileExtension("archive.tar.gz"));
+    }
+
+    @DisplayName("checkFileExtension 호출 시, 화이트리스트에 포함된 확장자만 허용한다.")
+    @Test
+    void testCheckFileExtension() {
+        assertTrue(EgovFileUploadUtil.checkFileExtension("image.png", ".png.pdf.txt"));
+        assertFalse(EgovFileUploadUtil.checkFileExtension("image.exe", ".png.pdf.txt"));
+        assertFalse(EgovFileUploadUtil.checkFileExtension("noext", ".png.pdf.txt"));
+        assertFalse(EgovFileUploadUtil.checkFileExtension("image.png", null));
+        assertFalse(EgovFileUploadUtil.checkFileExtension("image.png", ""));
+    }
+
+    @DisplayName("checkFileMaxSize 호출 시, 허용 크기 이하이면 true를 반환한다.")
+    @Test
+    void testCheckFileMaxSize() {
+        assertFalse(EgovFileUploadUtil.checkFileMaxSize(null, 1024));
+
+        MultipartFile smallFile = mock(MultipartFile.class);
+        when(smallFile.getSize()).thenReturn(512L);
+        assertTrue(EgovFileUploadUtil.checkFileMaxSize(smallFile, 1024));
+
+        MultipartFile bigFile = mock(MultipartFile.class);
+        when(bigFile.getSize()).thenReturn(2048L);
+        assertFalse(EgovFileUploadUtil.checkFileMaxSize(bigFile, 1024));
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovFormBasedFileUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovFormBasedFileUtilTest.java
@@ -1,0 +1,60 @@
+package egovframework.let.utl.fcc.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovFormBasedFileUtilTest {
+
+    @DisplayName("getTodayString 호출 시, 8자리 숫자 날짜 문자열을 반환한다.")
+    @Test
+    void testGetTodayString() {
+        String today = EgovFormBasedFileUtil.getTodayString();
+        assertEquals(8, today.length());
+        assertTrue(today.matches("\\d{8}"));
+    }
+
+    @DisplayName("getPhysicalFileName 호출 시, 하이픈이 없는 32자리 대문자 UUID 문자열을 반환한다.")
+    @Test
+    void testGetPhysicalFileName() {
+        String name = EgovFormBasedFileUtil.getPhysicalFileName();
+        assertTrue(name.matches("[0-9A-F]{32}"));
+    }
+
+    @DisplayName("saveFile 호출 시, InputStream의 내용을 파일로 저장하고 저장된 크기를 반환한다.")
+    @Test
+    void testSaveFileWritesContentAndReturnsSize(@TempDir Path tempDir) throws IOException {
+        // given
+        byte[] content = "hello egovframe".getBytes();
+        InputStream is = new ByteArrayInputStream(content);
+        File target = tempDir.resolve("sub").resolve("saved.txt").toFile();
+
+        // when
+        long size = EgovFormBasedFileUtil.saveFile(is, target);
+
+        // then
+        assertEquals(content.length, size);
+        assertTrue(target.exists());
+        assertArrayEquals(content, Files.readAllBytes(target.toPath()));
+    }
+
+    @DisplayName("saveFile 호출 시, 저장할 파일의 상위 디렉토리가 없으면 RuntimeException이 발생한다.")
+    @Test
+    void testSaveFileWithNoParentDirectoryThrows() {
+        // given
+        InputStream is = new ByteArrayInputStream("data".getBytes());
+        File fileWithoutParent = new File("no-parent-file.tmp");
+
+        // when / then
+        assertThrows(RuntimeException.class, () -> EgovFormBasedFileUtil.saveFile(is, fileWithoutParent));
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
@@ -1,0 +1,65 @@
+package egovframework.let.utl.fcc.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovNumberUtilTest {
+
+    @DisplayName("getRandomNum 호출 시, 시작숫자와 종료숫자 사이의 값을 반환한다.")
+    @Test
+    void testGetRandomNum() {
+        for (int i = 0; i < 100; i++) {
+            int result = EgovNumberUtil.getRandomNum(10, 20);
+            assertTrue(result >= 10 && result <= 20);
+        }
+    }
+
+    @DisplayName("getNumSearchCheck 호출 시, 특정 숫자가 포함되어 있는지 확인한다.")
+    @Test
+    void testGetNumSearchCheck() {
+        assertTrue(EgovNumberUtil.getNumSearchCheck(12345678, 567));
+        assertFalse(EgovNumberUtil.getNumSearchCheck(12345678, 9));
+    }
+
+    @DisplayName("getNumToStrCnvr 호출 시, 숫자를 문자열로 변환한다.")
+    @Test
+    void testGetNumToStrCnvr() {
+        assertEquals("20081212", EgovNumberUtil.getNumToStrCnvr(20081212));
+    }
+
+    @DisplayName("getNumToDateCnvr 호출 시, 8자리 숫자를 yyyy-MM-dd 형식으로 변환한다.")
+    @Test
+    void testGetNumToDateCnvrWithEightDigits() {
+        assertEquals("2008-12-12", EgovNumberUtil.getNumToDateCnvr(20081212));
+    }
+
+    @DisplayName("getNumToDateCnvr 호출 시, 8자리 또는 14자리가 아니면 IllegalArgumentException이 발생한다.")
+    @Test
+    void testGetNumToDateCnvrWithInvalidLengthThrows() {
+        assertThrows(IllegalArgumentException.class, () -> EgovNumberUtil.getNumToDateCnvr(2008));
+    }
+
+    @DisplayName("getNumberValidCheck 호출 시, 모든 문자가 숫자이면 true를 반환한다.")
+    @Test
+    void testGetNumberValidCheck() {
+        assertTrue(EgovNumberUtil.getNumberValidCheck("1234567890"));
+        assertFalse(EgovNumberUtil.getNumberValidCheck("123a567"));
+    }
+
+    @DisplayName("getNumberCnvr 호출 시, 특정 숫자를 다른 숫자로 치환한다.")
+    @Test
+    void testGetNumberCnvr() {
+        assertEquals(99945678, EgovNumberUtil.getNumberCnvr(12345678, 123, 999));
+    }
+
+    @DisplayName("checkRlnoInteger 호출 시, 음수이면 -1을 반환하고 그 외에는 소수점 포함 여부에 따라 1을 반환한다.")
+    @Test
+    void testCheckRlnoInteger() {
+        assertEquals(-1, EgovNumberUtil.checkRlnoInteger(-3.14));
+        assertEquals(1, EgovNumberUtil.checkRlnoInteger(3.14));
+        // double 표현은 항상 소수점을 포함하므로 정수 값이라도 실수(1)로 판정된다.
+        assertEquals(1, EgovNumberUtil.checkRlnoInteger(5.0));
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
@@ -1,0 +1,281 @@
+package egovframework.let.utl.fcc.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovStringUtilTest {
+
+    @DisplayName("cutString(source, output, length) 호출 시, 길이를 초과하면 자르고 접미어를 붙인다.")
+    @Test
+    void testCutStringWithSuffix() {
+        assertEquals("hel...", EgovStringUtil.cutString("hello world", "...", 3));
+        assertEquals("hi", EgovStringUtil.cutString("hi", "...", 5));
+        assertNull(EgovStringUtil.cutString(null, "...", 5));
+    }
+
+    @DisplayName("cutString(source, length) 호출 시, 길이를 초과하면 자른다.")
+    @Test
+    void testCutStringWithoutSuffix() {
+        assertEquals("hel", EgovStringUtil.cutString("hello world", 3));
+        assertEquals("hi", EgovStringUtil.cutString("hi", 5));
+        assertNull(EgovStringUtil.cutString(null, 5));
+    }
+
+    @DisplayName("isEmpty 호출 시, null 또는 빈 문자열이면 true를 반환한다.")
+    @Test
+    void testIsEmpty() {
+        assertTrue(EgovStringUtil.isEmpty(null));
+        assertTrue(EgovStringUtil.isEmpty(""));
+        assertFalse(EgovStringUtil.isEmpty(" "));
+        assertFalse(EgovStringUtil.isEmpty("bob"));
+    }
+
+    @DisplayName("remove 호출 시, 지정한 문자를 모두 제거한다.")
+    @Test
+    void testRemove() {
+        assertNull(EgovStringUtil.remove(null, 'u'));
+        assertEquals("", EgovStringUtil.remove("", 'u'));
+        assertEquals("qeed", EgovStringUtil.remove("queued", 'u'));
+        assertEquals("queued", EgovStringUtil.remove("queued", 'z'));
+    }
+
+    @DisplayName("removeCommaChar 호출 시, 콤마를 모두 제거한다.")
+    @Test
+    void testRemoveCommaChar() {
+        assertNull(EgovStringUtil.removeCommaChar(null));
+        assertEquals("", EgovStringUtil.removeCommaChar(""));
+        assertEquals("asdfgqweqe", EgovStringUtil.removeCommaChar("asdfg,qweqe"));
+    }
+
+    @DisplayName("removeMinusChar 호출 시, 하이픈을 모두 제거한다.")
+    @Test
+    void testRemoveMinusChar() {
+        assertNull(EgovStringUtil.removeMinusChar(null));
+        assertEquals("", EgovStringUtil.removeMinusChar(""));
+        assertEquals("asdfgqweqe", EgovStringUtil.removeMinusChar("a-sdfg-qweqe"));
+    }
+
+    @DisplayName("replace 호출 시, 대상 문자열을 모두 치환한다.")
+    @Test
+    void testReplace() {
+        assertEquals("hellx wxrld", EgovStringUtil.replace("hello world", "o", "x"));
+        assertEquals("hello", EgovStringUtil.replace("hello", "z", "x"));
+    }
+
+    @DisplayName("replaceOnce 호출 시, 대상 문자열을 첫 번째 것만 치환한다.")
+    @Test
+    void testReplaceOnce() {
+        assertEquals("hxllo world", EgovStringUtil.replaceOnce("hello world", "e", "x"));
+        assertEquals("hello", EgovStringUtil.replaceOnce("hello", "z", "x"));
+    }
+
+    @DisplayName("replaceChar 호출 시, subject에 포함된 문자를 object로 치환한다.")
+    @Test
+    void testReplaceChar() {
+        assertEquals("hellx world", EgovStringUtil.replaceChar("hello world", "o", "x"));
+    }
+
+    @DisplayName("indexOf 호출 시, 검색 문자열의 시작 위치를 반환하며 null이면 -1을 반환한다.")
+    @Test
+    void testIndexOf() {
+        assertEquals(-1, EgovStringUtil.indexOf(null, "a"));
+        assertEquals(-1, EgovStringUtil.indexOf("a", null));
+        assertEquals(0, EgovStringUtil.indexOf("", ""));
+        assertEquals(0, EgovStringUtil.indexOf("aabaabaa", "a"));
+        assertEquals(2, EgovStringUtil.indexOf("aabaabaa", "b"));
+        assertEquals(1, EgovStringUtil.indexOf("aabaabaa", "ab"));
+    }
+
+    @DisplayName("decode(4-arg) 호출 시, 소스와 비교값이 같으면 returnStr을, 다르면 defaultStr을 반환한다.")
+    @Test
+    void testDecodeFourArgs() {
+        assertEquals("foo", EgovStringUtil.decode(null, null, "foo", "bar"));
+        assertEquals("bar", EgovStringUtil.decode("", null, "foo", "bar"));
+        assertEquals("bar", EgovStringUtil.decode(null, "", "foo", "bar"));
+        assertEquals("foo", EgovStringUtil.decode("하이", "하이", "foo", "bar"));
+        assertEquals("bar", EgovStringUtil.decode("하이", "하이  ", "foo", "bar"));
+    }
+
+    @DisplayName("decode(3-arg) 호출 시, 소스와 비교값이 같으면 returnStr을, 다르면 sourceStr을 반환한다.")
+    @Test
+    void testDecodeThreeArgs() {
+        assertEquals("foo", EgovStringUtil.decode(null, null, "foo"));
+        assertEquals("", EgovStringUtil.decode("", null, "foo"));
+        assertNull(EgovStringUtil.decode(null, "", "foo"));
+        assertEquals("foo", EgovStringUtil.decode("하이", "하이", "foo"));
+        assertEquals("하이", EgovStringUtil.decode("하이", "하이 ", "foo"));
+        assertEquals("하이", EgovStringUtil.decode("하이", "바이", "foo"));
+    }
+
+    @DisplayName("isNullToString 호출 시, null이면 빈 문자열을, 아니면 trim된 문자열을 반환한다.")
+    @Test
+    void testIsNullToString() {
+        assertEquals("", EgovStringUtil.isNullToString(null));
+        assertEquals("abc", EgovStringUtil.isNullToString("  abc  "));
+        assertEquals("123", EgovStringUtil.isNullToString(123));
+    }
+
+    @DisplayName("nullConvert(Object) 호출 시, BigDecimal은 문자열로, null 또는 \"null\"은 빈 문자열로 변환한다.")
+    @Test
+    void testNullConvertObject() {
+        assertEquals("", EgovStringUtil.nullConvert((Object) null));
+        assertEquals("", EgovStringUtil.nullConvert((Object) "null"));
+        assertEquals("abc", EgovStringUtil.nullConvert((Object) "  abc  "));
+        assertEquals("3.14", EgovStringUtil.nullConvert((Object) new java.math.BigDecimal("3.14")));
+    }
+
+    @DisplayName("nullConvert(String) 호출 시, null/\"null\"/빈값/공백이면 빈 문자열을 반환한다.")
+    @Test
+    void testNullConvertString() {
+        assertEquals("", EgovStringUtil.nullConvert((String) null));
+        assertEquals("", EgovStringUtil.nullConvert("null"));
+        assertEquals("", EgovStringUtil.nullConvert(""));
+        assertEquals("", EgovStringUtil.nullConvert(" "));
+        assertEquals("abc", EgovStringUtil.nullConvert("  abc  "));
+    }
+
+    @DisplayName("zeroConvert(Object) 호출 시, null 또는 \"null\"이면 0을, 아니면 정수로 변환한다.")
+    @Test
+    void testZeroConvertObject() {
+        assertEquals(0, EgovStringUtil.zeroConvert((Object) null));
+        assertEquals(0, EgovStringUtil.zeroConvert((Object) "null"));
+        assertEquals(42, EgovStringUtil.zeroConvert((Object) " 42 "));
+    }
+
+    @DisplayName("zeroConvert(String) 호출 시, null/\"null\"/빈값/공백이면 0을, 아니면 정수로 변환한다.")
+    @Test
+    void testZeroConvertString() {
+        assertEquals(0, EgovStringUtil.zeroConvert((String) null));
+        assertEquals(0, EgovStringUtil.zeroConvert("null"));
+        assertEquals(0, EgovStringUtil.zeroConvert(""));
+        assertEquals(0, EgovStringUtil.zeroConvert(" "));
+        assertEquals(42, EgovStringUtil.zeroConvert(" 42 "));
+    }
+
+    @DisplayName("removeWhitespace 호출 시, 모든 공백문자를 제거한다.")
+    @Test
+    void testRemoveWhitespace() {
+        assertNull(EgovStringUtil.removeWhitespace(null));
+        assertEquals("", EgovStringUtil.removeWhitespace(""));
+        assertEquals("abc", EgovStringUtil.removeWhitespace("abc"));
+        assertEquals("abc", EgovStringUtil.removeWhitespace("   ab  c  "));
+    }
+
+    @DisplayName("checkHtmlView 호출 시, HTML 특수문자를 엔티티로 치환한다.")
+    @Test
+    void testCheckHtmlView() {
+        assertEquals("&lt;b&gt;&quot;hi&quot;&nbsp;there&lt;/b&gt;", EgovStringUtil.checkHtmlView("<b>\"hi\" there</b>"));
+    }
+
+    @DisplayName("split(source, separator) 호출 시, 구분자로 분리된 배열을 반환한다.")
+    @Test
+    void testSplit() {
+        assertArrayEquals(new String[] {"a", "b", "c"}, EgovStringUtil.split("a,b,c", ","));
+        assertArrayEquals(new String[] {"a"}, EgovStringUtil.split("a", ","));
+    }
+
+    @DisplayName("lowerCase / upperCase 호출 시, 대소문자를 변환하며 null은 그대로 반환한다.")
+    @Test
+    void testLowerUpperCase() {
+        assertNull(EgovStringUtil.lowerCase(null));
+        assertEquals("", EgovStringUtil.lowerCase(""));
+        assertEquals("abc", EgovStringUtil.lowerCase("aBc"));
+
+        assertNull(EgovStringUtil.upperCase(null));
+        assertEquals("", EgovStringUtil.upperCase(""));
+        assertEquals("ABC", EgovStringUtil.upperCase("aBc"));
+    }
+
+    @DisplayName("stripStart 호출 시, 앞쪽의 지정 문자를 제거한다.")
+    @Test
+    void testStripStart() {
+        assertNull(EgovStringUtil.stripStart(null, "*"));
+        assertEquals("", EgovStringUtil.stripStart("", "*"));
+        assertEquals("abc", EgovStringUtil.stripStart("abc", ""));
+        assertEquals("abc", EgovStringUtil.stripStart("abc", null));
+        assertEquals("abc", EgovStringUtil.stripStart("  abc", null));
+        assertEquals("abc  ", EgovStringUtil.stripStart("abc  ", null));
+        assertEquals("abc ", EgovStringUtil.stripStart(" abc ", null));
+        assertEquals("abc  ", EgovStringUtil.stripStart("yxabc  ", "xyz"));
+    }
+
+    @DisplayName("stripEnd 호출 시, 뒤쪽의 지정 문자를 제거한다.")
+    @Test
+    void testStripEnd() {
+        assertNull(EgovStringUtil.stripEnd(null, "*"));
+        assertEquals("", EgovStringUtil.stripEnd("", "*"));
+        assertEquals("abc", EgovStringUtil.stripEnd("abc", ""));
+        assertEquals("abc", EgovStringUtil.stripEnd("abc", null));
+        assertEquals("  abc", EgovStringUtil.stripEnd("  abc", null));
+        assertEquals("abc", EgovStringUtil.stripEnd("abc  ", null));
+        assertEquals(" abc", EgovStringUtil.stripEnd(" abc ", null));
+        assertEquals("  abc", EgovStringUtil.stripEnd("  abcyx", "xyz"));
+    }
+
+    @DisplayName("strip 호출 시, 앞뒤의 지정 문자를 모두 제거한다.")
+    @Test
+    void testStrip() {
+        assertNull(EgovStringUtil.strip(null, "*"));
+        assertEquals("", EgovStringUtil.strip("", "*"));
+        assertEquals("abc", EgovStringUtil.strip("abc", null));
+        assertEquals("abc", EgovStringUtil.strip("  abc", null));
+        assertEquals("abc", EgovStringUtil.strip("abc  ", null));
+        assertEquals("abc", EgovStringUtil.strip(" abc ", null));
+        assertEquals("  abc", EgovStringUtil.strip("  abcyx", "xyz"));
+    }
+
+    @DisplayName("split(source, separator, length) 호출 시, 지정된 길이의 배열로 분리하고 남는 칸은 빈 문자열로 채운다.")
+    @Test
+    void testSplitWithArrayLength() {
+        assertArrayEquals(new String[] {"a", "b,c"}, EgovStringUtil.split("a,b,c", ",", 2));
+        assertArrayEquals(new String[] {"a", "b", ""}, EgovStringUtil.split("a,b", ",", 3));
+    }
+
+    @DisplayName("getRandomStr 호출 시, 시작문자와 종료문자 사이의 문자를 반환하며, 시작문자가 종료문자보다 크면 예외가 발생한다.")
+    @Test
+    void testGetRandomStr() {
+        for (int i = 0; i < 50; i++) {
+            String result = EgovStringUtil.getRandomStr('A', 'Z');
+            assertEquals(1, result.length());
+            assertTrue(result.charAt(0) >= 'A' && result.charAt(0) <= 'Z');
+        }
+        assertThrows(IllegalArgumentException.class, () -> EgovStringUtil.getRandomStr('Z', 'A'));
+    }
+
+    @DisplayName("getEncdDcd 호출 시, 지정한 캐릭터셋으로 인/디코딩하며 null 입력 시 null을 반환한다.")
+    @Test
+    void testGetEncdDcd() throws Exception {
+        assertNull(EgovStringUtil.getEncdDcd(null, "UTF-8", "UTF-8"));
+        assertEquals("hello", EgovStringUtil.getEncdDcd("hello", "UTF-8", "UTF-8"));
+        assertNull(EgovStringUtil.getEncdDcd("hello", "INVALID-CHARSET", "UTF-8"));
+    }
+
+    @DisplayName("getSpclStrCnvr 호출 시, <, >, &을 HTML 엔티티로 치환한다.")
+    @Test
+    void testGetSpclStrCnvr() {
+        assertEquals("&lt;a&gt;&amp;&lt;/a&gt;", EgovStringUtil.getSpclStrCnvr("<a>&</a>"));
+    }
+
+    @DisplayName("getTimeStamp 호출 시, 17자리 숫자 타임스탬프 문자열을 반환한다.")
+    @Test
+    void testGetTimeStamp() {
+        String timeStamp = EgovStringUtil.getTimeStamp();
+        assertEquals(17, timeStamp.length());
+        assertTrue(timeStamp.matches("\\d{17}"));
+    }
+
+    @DisplayName("getHtmlStrCnvr 호출 시, HTML 엔티티를 원래 문자로 복원한다.")
+    @Test
+    void testGetHtmlStrCnvr() {
+        assertEquals("<a>&\"'</a> ", EgovStringUtil.getHtmlStrCnvr("&lt;a&gt;&amp;&quot;&apos;&lt;/a&gt;&nbsp;"));
+    }
+
+    @DisplayName("addMinusChar 호출 시, 8자리 날짜 문자열에 하이픈을 추가하며 그 외 길이는 빈 문자열을 반환한다.")
+    @Test
+    void testAddMinusChar() {
+        assertEquals("2010-09-01", EgovStringUtil.addMinusChar("20100901"));
+        assertEquals("", EgovStringUtil.addMinusChar("2010"));
+    }
+}


### PR DESCRIPTION
## 변경 내용

기존 테스트가 없던 유틸리티 클래스 7종에 순수 단위 테스트를 추가했습니다.

- `EgovWebUtil`, `EgovStringUtil`, `EgovNumberUtil`, `EgovDateUtil`: 순수 로직 검증
- `EgovFileUploadUtil`, `EgovFormBasedFileUtil`, `EgovFileMngUtil`: 파일 I/O가 관여하는 부분은 JUnit5 `@TempDir`로 실제 파일시스템 접근 없이 격리하고, 외부 의존성(`EgovPropertyService`, `EgovIdGnrService`, `MultipartFile` 등)은 Mockito로 mock 처리해 오프라인 재현 가능하게 구성했습니다.

`EgovFormBasedFileUtil`의 `downloadFile`/`viewFile`(HttpServletResponse 직접 의존)은 mocking 복잡도 대비 가치가 낮아 제외했습니다.

테스트 작성 과정에서 실제 소스의 기존 동작(예: `isLeapYear`가 윤년일 때 false를 반환하는 등)을 있는 그대로 검증했으며, 이번 PR에서 동작 자체를 변경하지는 않았습니다.

## 테스트
- [x] 신규 테스트 95개 전부 통과
- [x] 기존 테스트 중 일부(JWT 시크릿 미설정, 로그인 API 서버 미기동, ChromeDriver 연결 불가)는 이 변경과 무관하게 upstream/main 클린 체크아웃에서도 동일하게 실패함을 확인

- [ ] 단일 주제만 다룸 (다른 변경 없음, 테스트 추가만)
- [ ] 기존 동작에 영향 없음