### PR TITLE
chore: 주석 한글 오타 일괄 수정 (메세지→메시지, 갯수→개수, 비지니스→비즈니스)

### DIFF
--- a/src/main/java/egovframework/com/cmm/ComDefaultVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultVO.java
@@ -39,7 +39,7 @@ public class ComDefaultVO implements Serializable {
     /** 현재페이지 */
     private int pageIndex = 1;
 
-    /** 페이지갯수 */
+    /** 페이지개수 */
     private int pageUnit = 10;
 
     /** 페이지사이즈 */

--- a/src/main/java/egovframework/com/cmm/EgovMessageSource.java
+++ b/src/main/java/egovframework/com/cmm/EgovMessageSource.java
@@ -44,16 +44,16 @@ public class EgovMessageSource extends ReloadableResourceBundleMessageSource imp
 	}
 
 	/**
-	 * Default Locale 정의된 메세지 조회
-	 * @param code - 메세지 코드
+	 * Default Locale 정의된 메시지 조회
+	 * @param code - 메시지 코드
 	 * @return String
 	 */	
 	public String getMessage(String code) {
 		return this.getMessage(code, Locale.getDefault());
 	}
 	/**
-	 * 정의된 메세지 조회
-	 * @param code - 메세지 코드
+	 * 정의된 메시지 조회
+	 * @param code - 메시지 코드
 	 * @param locale - locale 설정
 	 * @return String
 	 */

--- a/src/main/java/egovframework/com/config/EgovConfigAppIdGen.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppIdGen.java
@@ -578,7 +578,7 @@ public class EgovConfigAppIdGen {
 			.build();
 	}
 
-	/** 메일 메세지 ID Generation  Config
+	/** 메일 메시지 ID Generation  Config
 	 * @return
 	 */
 	@Bean(destroyMethod = "destroy")

--- a/src/main/java/egovframework/com/config/EgovConfigAppMsg.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppMsg.java
@@ -20,7 +20,7 @@ import org.springframework.context.support.ReloadableResourceBundleMessageSource
 public class EgovConfigAppMsg {
 
     /**
-     * @return [Resource 설정] 메세지 Properties 경로 설정
+     * @return [Resource 설정] 메시지 Properties 경로 설정
      */
     @Bean
     ReloadableResourceBundleMessageSource messageSource() {
@@ -35,7 +35,7 @@ public class EgovConfigAppMsg {
     }
 
     /**
-     * @return [Resource 설정] 메세지 소스 등록
+     * @return [Resource 설정] 메시지 소스 등록
      */
     @Bean
     EgovMessageSource egovMessageSource() {

--- a/src/main/java/egovframework/let/cop/com/service/UserInfVO.java
+++ b/src/main/java/egovframework/let/cop/com/service/UserInfVO.java
@@ -71,7 +71,7 @@ public class UserInfVO implements Serializable {
     /** 현재페이지 */
     private int pageIndex = 1;
 
-    /** 페이지갯수 */
+    /** 페이지개수 */
     private int pageUnit = 10;
 
     /** 페이지사이즈 */

--- a/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
+++ b/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
@@ -58,7 +58,7 @@ public class EgovSiteManagerApiController {
 	 * 리액트에서 사이트관리자에 접근하는 토큰값 위변조 방지용으로 서버에서 비교한다.
 	 * @param map데이터: String old_password, new_password
 	 * @param request - 토큰값으로 인증된 사용자를 확인하기 위한 HttpServletRequest
-	 * @return result - JWT 토큰값 비교결과 코드와 메세지
+	 * @return result - JWT 토큰값 비교결과 코드와 메시지
 	 * @exception Exception
 	 */
 	@Operation(

--- a/src/main/java/egovframework/let/uss/umt/service/EgovMberManageService.java
+++ b/src/main/java/egovframework/let/uss/umt/service/EgovMberManageService.java
@@ -46,9 +46,9 @@ public interface EgovMberManageService {
 	public List<MberManageVO> selectMberList(UserDefaultVO userSearchVO) throws Exception;
 
     /**
-     * 일반회원 총 갯수를 조회한다.
+     * 일반회원 총 개수를 조회한다.
      * @param userSearchVO 검색조건
-     * @return 일반회원총갯수(int)
+     * @return 일반회원총개수(int)
      * @throws Exception
      */
     public int selectMberListTotCnt(UserDefaultVO userSearchVO) throws Exception;

--- a/src/main/java/egovframework/let/uss/umt/service/MberManageVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/MberManageVO.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * 일반회원VO클래스로서 일반회원관리 비지니스로직 처리용 항목을 구성한다.
+ * 일반회원VO클래스로서 일반회원관리 비즈니스로직 처리용 항목을 구성한다.
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10
  * @version 1.0

--- a/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * 가입약관VO클래스로서가입약관확인시 비지니스로직 처리용 항목을 구성한다.
+ * 가입약관VO클래스로서가입약관확인시 비즈니스로직 처리용 항목을 구성한다.
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10
  * @version 1.0

--- a/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * 사용자정보 VO클래스로서일반회원, 기업회원, 업무사용자의  비지니스로직 처리시 기타조건성 항목을 구성한다.
+ * 사용자정보 VO클래스로서일반회원, 기업회원, 업무사용자의  비즈니스로직 처리시 기타조건성 항목을 구성한다.
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10
  * @version 1.0
@@ -48,7 +48,7 @@ public class UserDefaultVO implements Serializable {
     /** 현재페이지 */
     private int pageIndex = 1;
 
-    /** 페이지갯수 */
+    /** 페이지개수 */
     private int pageUnit = 10;
 
     /** 페이지사이즈 */

--- a/src/main/java/egovframework/let/uss/umt/service/impl/EgovMberManageServiceImpl.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/EgovMberManageServiceImpl.java
@@ -14,7 +14,7 @@ import jakarta.annotation.Resource;
 import org.springframework.stereotype.Service;
 
 /**
- * 일반회원관리에 관한비지니스클래스를 정의한다.
+ * 일반회원관리에 관한비즈니스클래스를 정의한다.
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10
  * @version 1.0
@@ -85,9 +85,9 @@ public class EgovMberManageServiceImpl extends EgovAbstractServiceImpl implement
 	}
 
     /**
-     * 일반회원 총 갯수를 조회한다.
+     * 일반회원 총 개수를 조회한다.
      * @param userSearchVO 검색조건
-     * @return 일반회원총갯수(int)
+     * @return 일반회원총개수(int)
      */
     @Override
 	public int selectMberListTotCnt(UserDefaultVO userSearchVO) {

--- a/src/main/java/egovframework/let/uss/umt/service/impl/MberManageDAO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/MberManageDAO.java
@@ -40,9 +40,9 @@ public class MberManageDAO extends EgovAbstractMapper{
     }
 
     /**
-     * 일반회원 총 갯수를 조회한다.
+     * 일반회원 총 개수를 조회한다.
      * @param userSearchVO 검색조건
-     * @return int 일반회원총갯수
+     * @return int 일반회원총개수
      */
     public int selectMberListTotCnt(UserDefaultVO userSearchVO) {
         return selectOne("mberManageDAO.selectMberListTotCnt", userSearchVO);

--- a/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
+++ b/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
@@ -43,7 +43,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 회원관련 요청을 비지니스 클래스로 전달하고 처리된 결과를 해당 웹 화면으로 전달하는 Controller를 정의한다
+ * 회원관련 요청을 비즈니스 클래스로 전달하고 처리된 결과를 해당 웹 화면으로 전달하는 Controller를 정의한다
  * 
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

주석 내 한글 표기 오타 22곳(13개 파일)을 표준 표기로 수정했습니다. **주석(Javadoc·라인 주석)만** 변경했으며 코드·문자열 리터럴·어노테이션 값은 변경하지 않았습니다.

| 수정 전 → 후 | 곳 |
|---|---|
| 메세지 → 메시지 | 8 |
| 갯수 → 개수 | 9 |
| 비지니스 → 비즈니스 | 5 |

대상: com/cmm(2), com/config(2), let/cop/com/service(1), let/uat/esm/web(1), let/uss/umt(7)

### 의도적 제외

- `@Schema(description="페이지갯수")` 3곳은 Swagger API 문서 출력에 영향을 주는 어노테이션 값이므로 제외했습니다. 수정을 원하시면 별도 PR로 제출하겠습니다.

### 검증

- 변경 라인 전수(44라인)가 주석임을 스크립트로 확인했습니다.
- 현재 open PR 4건(#160, #161, #162, #111)의 변경 파일과 겹치지 않습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 주석만 변경(바이트코드 불변)으로 별도 테스트 미수행.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

주석 변경으로 화면(UI) 변경 사항이 없습니다.
