### PR TITLE
심플홈페이지 백엔드에 AI-RAG 챗봇 기능을 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ MYSQL_DATABASE=egovdb
 MYSQL_USER=egov
 MYSQL_PASSWORD=changeme
 MYSQL_ROOT_PASSWORD=changemeRoot
+
+# 구글제미나이 — API 키와 모델 명을 환경 변수로 설정
+GOOGLE_GENAI_API_KEY=your_google_genai_api_key_here
+API_MODEL=gemini-2.5-flash

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![workflow](https://github.com/eGovFramework/egovframe-template-simple-backend/actions/workflows/maven.yml/badge.svg)
 
 ※ 본 프로젝트는 기존 JSP 뷰 방식에서 벗어나 BackEnd와 FrontEnd를 분리한 아키텍처를 제공하는 예시 프로젝트입니다. 실제 구현 시 참고용으로 활용하시기 바랍니다.
+※ AI-RAG기능 사용 시 인증/제한 없는 데모, 노출·과금은 도입자 책임이며, 운영 전 접근통제 및 rate limit 가 필요 합니다.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<tomcat-embed.version>10.1.52</tomcat-embed.version>
 		<commons-beanutils.version>1.11.0</commons-beanutils.version>
 		<commons-lang3.version>3.18.0</commons-lang3.version>
+		<spring.ai.version>1.1.1</spring.ai.version>
 	</properties>
 
 	<repositories>
@@ -60,8 +61,28 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+		<!-- Spring AI Milestones Repository 추가 -->
+		<repository>
+	        <id>spring-milestones</id>
+	        <name>Spring Milestones</name>
+	        <url>https://repo.spring.io/milestone</url>
+	        <snapshots>
+	            <enabled>false</enabled>
+	        </snapshots>
+	    </repository>
 	</repositories>
-
+	<!-- Spring AI BOM 추가 -->
+	<dependencyManagement>
+	    <dependencies>
+	        <dependency>
+	            <groupId>org.springframework.ai</groupId>
+	            <artifactId>spring-ai-bom</artifactId>
+	            <version>${spring.ai.version}</version>
+	            <type>pom</type>
+	            <scope>import</scope>
+	        </dependency>
+	    </dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<!-- spring boot dependency start -->
 		<dependency>
@@ -346,6 +367,11 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-otel</artifactId>
+		</dependency>
+		<!-- Spring AI - Google GenAI -->
+		<dependency>
+		    <groupId>org.springframework.ai</groupId>
+		    <artifactId>spring-ai-starter-model-google-genai</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/egovframework/com/security/SecurityConfig.java
+++ b/src/main/java/egovframework/com/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
             "/schedule/{schdulId}", // 일정 상세조회
             "/image", // 갤러리 이미지보기
             "/file", // 파일 다운로드 — GET만 공개 (2026/06/26 보안취약점 대응: POST(삭제)는 인증 요구로 전환)
+            "/api/gemini/rag_chat", // RAG 챗봇 응답
     };
 
     // 인증 예외 List

--- a/src/main/java/egovframework/let/main/service/EgovRAGService.java
+++ b/src/main/java/egovframework/let/main/service/EgovRAGService.java
@@ -1,0 +1,94 @@
+package egovframework.let.main.service;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.ai.chat.client.ChatClient;
+import java.util.*;
+import java.time.Duration;
+
+@Service
+public class EgovRAGService {
+	private final ChatClient chatClient;
+	private final List<DocumentVector> store = new ArrayList<>();
+	private static final long RESPONSE_TIMEOUT_SECONDS = 60;
+	
+	public EgovRAGService(ChatClient.Builder chatBuilder, RestTemplateBuilder restTemplateBuilder) {
+		RestTemplate restTemplate = restTemplateBuilder
+				.setConnectTimeout(Duration.ofSeconds(RESPONSE_TIMEOUT_SECONDS))
+				.setReadTimeout(Duration.ofSeconds(RESPONSE_TIMEOUT_SECONDS))
+				.build();
+		
+		this.chatClient = chatBuilder.build();
+		indexDocuments(null);
+	}
+
+	public void indexDocuments(List<String> documents) {
+		store.clear();
+		List<String> docsToIndex = new ArrayList<>();
+		if (documents != null) {
+			docsToIndex.addAll(documents);
+		}
+		
+		try {
+			List<String> externalUrl = new ArrayList<>();
+			externalUrl.add(0, "https://raw.githubusercontent.com/eGovFramework/egovframe-template-simple-react/refs/heads/main/README.md");
+			externalUrl.add(1, "https://raw.githubusercontent.com/eGovFramework/egovframe-template-simple-backend/refs/heads/main/README.md");
+			RestTemplate restTemplate = new RestTemplate();
+			for (int i = 0; i < externalUrl.size(); i++) {
+				String url = externalUrl.get(i);
+				String urlContent = restTemplate.getForObject(url, String.class);
+				if (urlContent != null && !urlContent.isBlank()) {
+					docsToIndex.add(i, urlContent);
+				}
+			}
+		} catch (Exception e) {
+			System.err.println("외부 URL 파일 로드 실패: " + e.getMessage());
+		}
+		
+		for (int i = 0; i < docsToIndex.size(); i++) {
+			String doc = docsToIndex.get(i);
+			store.add(new DocumentVector("doc-" + i, doc));
+		}
+	}
+
+	// 모든 문서를 context로 제공하는 방식
+	public String answer(String userQuery) {
+		try {
+			StringBuilder systemBuilder = new StringBuilder();
+			systemBuilder.append("앞으로의 모든 답변은 반드시 질문한 언어와 동일한 언어로 해줘. 당신은 제공된 문서를 기반으로 답변하는 챗봇입니다. 다음 문서를 참고하여 질문에 답변하세요. ");
+			systemBuilder.append("문서에 답이 없으면 모른다고 하고 환각 증상이 없다고 말하세요. ");
+			systemBuilder.append("\n\nDocuments:\n");
+			
+			for (int i = 0; i < store.size(); i++) {
+				String docText = store.get(i).text;
+				systemBuilder.append(String.format("[DOC %d]\n%s\n\n", i + 1, docText));
+			}
+			String systemInstruction = systemBuilder.toString();
+			
+			String response = chatClient.prompt()
+					.system(systemInstruction)
+					.user(userQuery + " 앞으로의 모든 답변은 반드시 질문한 언어와 동일한 언어로 해줘.")
+					.call()
+					.content();
+			
+			return response;
+		} catch (org.springframework.web.client.ResourceAccessException e) {
+			System.err.println("AI 응답 타임아웃 (연결): " + e.getMessage());
+			return "죄송합니다. AI 서비스 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.";
+		} catch (Exception e) {
+			System.err.println("AI 응답 처리 중 오류 발생: " + e.getMessage());
+			e.printStackTrace();
+			return "죄송합니다. 응답을 처리하는 중에 오류가 발생했습니다.";
+		}
+	}
+
+	private static class DocumentVector {
+		final String id;
+		final String text;
+
+		DocumentVector(String id, String text) {
+			this.id = id;
+			this.text = text;
+		}
+	}
+}

--- a/src/main/java/egovframework/let/main/web/EgovMainApiController.java
+++ b/src/main/java/egovframework/let/main/web/EgovMainApiController.java
@@ -7,12 +7,14 @@ import jakarta.annotation.Resource;
 
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import egovframework.com.cmm.ResponseCode;
 import egovframework.com.cmm.service.ResultVO;
 import egovframework.let.cop.bbs.dto.request.BbsSearchRequestDTO;
 import egovframework.let.cop.bbs.dto.response.BbsManageListResponseDTO;
 import egovframework.let.cop.bbs.service.EgovBBSManageService;
+import egovframework.let.main.service.EgovRAGService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -44,6 +46,29 @@ public class EgovMainApiController {
 	@Resource(name = "EgovBBSManageService")
     private EgovBBSManageService bbsMngService;
 
+	private final EgovRAGService ragService; // RAGService 주입
+	public EgovMainApiController(EgovRAGService ragService) {
+        this.ragService = ragService; // RAG 기능때문에 추가
+    }
+	/**
+	 * RAG 기능으로 README.md 파일의 질문조회 후 답변
+	 * @return MD 형식의 응답 문자열
+	 *
+	 * @throws Exception
+	 */
+	@Operation(
+			summary = "RAG Chat",
+			description = "RAG 기능으로 README.md 파일의 질문조회 후 답변",
+			tags = {"EgovMainApiController"}
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "조회 성공")
+	})
+	@GetMapping("/api/gemini/rag_chat")
+    public String ragChat(@RequestParam(value = "prompt") String prompt) {
+        return ragService.answer(prompt);// 유사도 검색기능 제거
+    }
+	
 	/**
 	 * 템플릿 메인 페이지 조회
 	 * @return 메인페이지 정보 Map [key : 항목명]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -101,9 +101,9 @@ logging.file.path=./log
 logging.rollingpolicy.maxFileSize=10MB
 logging.rollingpolicy.maxHistory=30
 
-# Tracing - 로그에 traceId/spanId 표시용. service.name 으로 사용될 애플리케이션 이름.
+# Tracing - \u00eb\u00a1\u009c\u00ea\u00b7\u00b8\u00ec\u0097\u0090 traceId/spanId \u00ed\u0091\u009c\u00ec\u008b\u009c\u00ec\u009a\u00a9. service.name \u00ec\u009c\u00bc\u00eb\u00a1\u009c \u00ec\u0082\u00ac\u00ec\u009a\u00a9\u00eb\u0090\u00a0 \u00ec\u0095\u00a0\u00ed\u0094\u008c\u00eb\u00a6\u00ac\u00ec\u00bc\u0080\u00ec\u009d\u00b4\u00ec\u0085\u0098 \u00ec\u009d\u00b4\u00eb\u00a6\u0084.
 spring.application.name=egovframe-template-simple-backend
-# 레퍼런스 목적상 모든 요청에 트레이스가 표시되도록 기본 1.0. 운영에서는 부하에 맞게 낮춘다(예: 0.1).
+# \u00eb\u00a0\u0088\u00ed\u008d\u00bc\u00eb\u009f\u00b0\u00ec\u008a\u00a4 \u00eb\u00aa\u00a9\u00ec\u00a0\u0081\u00ec\u0083\u0081 \u00eb\u00aa\u00a8\u00eb\u0093\u00a0 \u00ec\u009a\u0094\u00ec\u00b2\u00ad\u00ec\u0097\u0090 \u00ed\u008a\u00b8\u00eb\u00a0\u0088\u00ec\u009d\u00b4\u00ec\u008a\u00a4\u00ea\u00b0\u0080 \u00ed\u0091\u009c\u00ec\u008b\u009c\u00eb\u0090\u0098\u00eb\u008f\u0084\u00eb\u00a1\u009d \u00ea\u00b8\u00b0\u00eb\u00b3\u00b8 1.0. \u00ec\u009a\u00b4\u00ec\u0098\u0081\u00ec\u0097\u0090\u00ec\u0084\u009c\u00eb\u008a\u0094 \u00eb\u00b6\u0080\u00ed\u0095\u0098\u00ec\u0097\u0090 \u00eb\u00a7\u009e\u00ea\u00b2\u008c \u00eb\u0082\u00ae\u00ec\u00b6\u0098\u00eb\u008b\u00a4(\u00ec\u0098\u0088: 0.1).
 management.tracing.sampling.probability=1.0
 
 #swaggerdoc
@@ -127,3 +127,10 @@ Sns.naver.clientSecret=YOUR_CLIENT_SECRET
 Sns.naver.callbackUrl=http://localhost:3000/login/naver/callback
 Sns.kakao.clientId=YOUR_CLIENT_ID
 Sns.kakao.callbackUrl=http://localhost:3000/login/kakao/callback
+
+#Ai
+GOOGLE_GENAI_API_KEY=${GOOGLE_GENAI_API_KEY}
+API_MODEL=${API_MODEL}
+spring.config.import=optional:file:.env[.properties]
+spring.ai.google.genai.api-key=${GOOGLE_GENAI_API_KEY}
+spring.ai.google.genai.chat.options.model=${API_MODEL}


### PR DESCRIPTION
## 수정 사유 Reason for modification

심플홈페이지에 대한 백엔드 및 프런트엔드에 대한 정보를 AI-RAG기능을 추가하여 README.md 파일을 질문 형식으로 편리하게 정보를 얻을 수 있게 합니다. 
참고로, EgovRAGService.java 소스에서 아래 문서 경로를 운영사이트의 URL로 추가하면 사이트의 AI챗봇 으로도 활용 가능합니다.
- https://raw.githubusercontent.com/eGovFramework/egovframe-template-simple-react/refs/heads/main/README.md 

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [x] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
1. EgovRAGService.java 파일에서 아래 내용 적용. 
- 요청마다 재인덱싱 → 요청할 때마다 문서를 재인덱싱하지 않도록 생성자에 문서를 가져오도록 변경.
- 외부 호출 타임아웃 부재 + 공유 상태 동시성 결함 → 외부 URL을 타임아웃 시간을 추고, 예외처리 구문을 추가해서 변경.
- 임베딩이 실제 의미 벡터가 아님 → 유사도 검색 기능을 사용하지 않도록 임베딩을 없애는 것으로 처리.
- (참고) 로깅 → 전체 프롬프트·문서 내용을 System.out/err로 출력하는 부분 제거.
2. README.md 파일에 아래 내용 추가. 
- 무인증·무제한 외부 LLM 엔드포인트: 인증·호출 제한 없이 과금되는 외부 API를 호출 → 도입자가 자기 키로 연결하는 데모 성격이므로, 코드 차단보다는 README·인라인에 "인증/제한 없는 데모, 노출·과금은 도입자 책임, 운영 전 접근통제·rate limit 필요"를 명시하는 내용을 추가.
3. .env.example 파일에 신규 필수 변수(API_KEY,API_MODEL) 문서화 추가.
4. application.properties 파일에 Ai 클라우드변수 추가(optional 옵션으로 .env 파일도 혼합해서 사용가능하게 처리)
5. EgovMainApiController.java 파일에 심플홈페이지 프런트인 리액트에서 접근하는 @GetMapping("/api/gemini/rag_chat") 추가 
6. pom.xml 파일에 Spring AI 의존성 추가.
7. SecurityConfig.java 파일에 AI-RAG접속용 Get 인증예외 List 추가.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

스웨거로 테스트 : http://localhost:8080/swagger-ui/index.html#/EgovMainApiController/ragChat 
노드js 버전은 무엇을 사용하나요 로 Prompt에 입력 후 결과 확인(아래)
<img width="1327" height="666" alt="image" src="https://github.com/user-attachments/assets/6eb0ebb8-5500-48f8-ac6b-951dfbf065c0" />
