### PR TITLE
docs: 소스 주석 표기 오타 수정 (셋팅→세팅, 컨텐츠→콘텐츠)

### DIFF
--- a/src/main/java/egovframework/com/config/EgovConfigAppIdGen.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppIdGen.java
@@ -1135,7 +1135,7 @@ public class EgovConfigAppIdGen {
 			.build();
 	}
 
-	/** 마이페이지 컨텐츠 ID Generation  Config
+	/** 마이페이지 콘텐츠 ID Generation  Config
 	 * @return
 	 */
 	@Bean(destroyMethod = "destroy")

--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
@@ -187,7 +187,7 @@ public class EgovIndvdlSchdulManageApiController {
 			_atchFileId = fileMngService.insertFileInfs(_result); //파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
 		}
 
-		// 리턴받은 첨부파일ID를 셋팅한다..
+		// 리턴받은 첨부파일ID를 세팅한다..
 		indvdlSchdulManageVO.setAtchFileId(_atchFileId); // 첨부파일 ID
 
 		//아이디 설정
@@ -362,7 +362,7 @@ public class EgovIndvdlSchdulManageApiController {
 				List<FileVO> _result = fileUtil.parseFileInf(files, "DSCH_", 0, _atchFileId, "");
 				_atchFileId = fileMngService.insertFileInfs(_result);
 
-				// 첨부파일 ID 셋팅
+				// 첨부파일 ID 세팅
 				indvdlSchdulManageVO.setAtchFileId(_atchFileId); // 첨부파일 ID
 
 			} else {

--- a/src/main/java/egovframework/let/main/web/EgovMainApiController.java
+++ b/src/main/java/egovframework/let/main/web/EgovMainApiController.java
@@ -65,7 +65,7 @@ public class EgovMainApiController {
 		ResultVO resultVO = new ResultVO();
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 
-		// 공지사항 메인 컨텐츠 조회 시작 ---------------------------------
+		// 공지사항 메인 콘텐츠 조회 시작 ---------------------------------
 		PaginationInfo paginationInfo = new PaginationInfo();
 
 		paginationInfo.setCurrentPageNo(1);

--- a/src/main/java/egovframework/let/uss/umt/service/impl/EgovMberManageServiceImpl.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/EgovMberManageServiceImpl.java
@@ -50,7 +50,7 @@ public class EgovMberManageServiceImpl extends EgovAbstractServiceImpl implement
 	 */
 	@Override
 	public int insertMber(MberManageVO mberManageVO) throws Exception  {
-		//고유아이디 셋팅
+		//고유아이디 세팅
 		String uniqId = idgenService.getNextStringId();
 		mberManageVO.setUniqId(uniqId);
 		// 저장 형식 = SHA-256(id || SHA-256(id || password))


### PR DESCRIPTION
## 수정 내용
소스 코드 주석의 외래어 표기 오타를 외래어 표기법 권장 표기로 수정했습니다.

- `셋팅` → `세팅`
- `컨텐츠` → `콘텐츠`

| 파일 | 수정 |
|---|---|
| `.../cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java` | 셋팅→세팅 2곳 |
| `.../uss/umt/service/impl/EgovMberManageServiceImpl.java` | 셋팅→세팅 1곳 |
| `.../com/config/EgovConfigAppIdGen.java` | 컨텐츠→콘텐츠 1곳 |
| `.../let/main/web/EgovMainApiController.java` | 컨텐츠→콘텐츠 1곳 |

모두 **주석 텍스트만** 수정했으며 코드·식별자·문자열 리터럴 변경은 없습니다. (기존 주석 오타 PR #163과 파일이 겹치지 않습니다.)
