### PR TITLE
fix: EgovWebUtil 정규식 반복 컴파일 제거 + 정확성 결함 2건 수정 (%00 NPE·파일명 훼손)

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -18,11 +18,16 @@ import java.util.regex.Pattern;
  *  2018.08.17   신용호       filePathBlackList 수정
  *  2018.10.10   신용호       . => \\.으로 수정
  *  2024.12.04   신용호       filePathBlackList() basePath 파라미터 추가
+ *  2026.07.19   EricSeokgon  성능: 상수 정규식 반복 컴파일 제거 / 정확성: clearXSSMaximum %00 replacement NULL 및 fileInjectPathReplaceAll 경로 제거 결함 수정
  * </pre>
  */
 
 public class EgovWebUtil {
 
+	// 성능: 매 호출마다 Pattern.compile이 반복되지 않도록 정규식은 클래스 로딩 시 1회만 컴파일한다.
+	// (정규식 의미가 없는 문자 그대로의 치환은 String.replace 로 대체 — 패턴 컴파일 자체가 불필요)
+	private static final Pattern SPACE_PATTERN = Pattern.compile("\\p{Space}");
+	private static final Pattern IP_PATTERN = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
 
 	public static ResultVO handleAuthError(int code, String msg) {
 		ResultVO resultVO = new ResultVO();
@@ -37,14 +42,14 @@ public class EgovWebUtil {
 
 		String returnValue = value;
 
-		returnValue = returnValue.replaceAll("&", "&amp;");
-		returnValue = returnValue.replaceAll("<", "&lt;");
-		returnValue = returnValue.replaceAll(">", "&gt;");
-		returnValue = returnValue.replaceAll("\"", "&#34;");
-		returnValue = returnValue.replaceAll("\'", "&#39;");
-		returnValue = returnValue.replaceAll("\\.", "&#46;");
-		returnValue = returnValue.replaceAll("%2E", "&#46;");
-		returnValue = returnValue.replaceAll("%2F", "&#47;");
+		returnValue = returnValue.replace("&", "&amp;");
+		returnValue = returnValue.replace("<", "&lt;");
+		returnValue = returnValue.replace(">", "&gt;");
+		returnValue = returnValue.replace("\"", "&#34;");
+		returnValue = returnValue.replace("\'", "&#39;");
+		returnValue = returnValue.replace(".", "&#46;");
+		returnValue = returnValue.replace("%2E", "&#46;");
+		returnValue = returnValue.replace("%2F", "&#47;");
 		return returnValue;
 	}
 
@@ -52,16 +57,18 @@ public class EgovWebUtil {
 		String returnValue = value;
 		returnValue = clearXSSMinimum(returnValue);
 
-		returnValue = returnValue.replaceAll("%00", null);
+		// 정확성: 기존 코드는 replaceAll("%00", null) 로 replacement 에 null 을 넘겨
+		// 입력에 "%00" 이 포함되면 NullPointerException 이 발생했다("%00" 제거가 의도).
+		returnValue = returnValue.replace("%00", "");
 
-		returnValue = returnValue.replaceAll("%", "&#37;");
+		returnValue = returnValue.replace("%", "&#37;");
 
 		// \\. => .
 
-		returnValue = returnValue.replaceAll("\\.\\./", ""); // ../
-		returnValue = returnValue.replaceAll("\\.\\.\\\\", ""); // ..\
-		returnValue = returnValue.replaceAll("\\./", ""); // ./
-		returnValue = returnValue.replaceAll("%2F", "");
+		returnValue = returnValue.replace("../", ""); // ../
+		returnValue = returnValue.replace("..\\", ""); // ..\
+		returnValue = returnValue.replace("./", ""); // ./
+		returnValue = returnValue.replace("%2F", "");
 
 		return returnValue;
 	}
@@ -72,7 +79,7 @@ public class EgovWebUtil {
 			return "";
 		}
 
-		returnValue = returnValue.replaceAll("\\.\\.", "");
+		returnValue = returnValue.replace("..", "");
 
 		return returnValue;
 	}
@@ -108,10 +115,10 @@ public class EgovWebUtil {
 			return "";
 		}
 
-		returnValue = returnValue.replaceAll("/", "");
-		returnValue = returnValue.replaceAll("\\\\", ""); // \
-		returnValue = returnValue.replaceAll("\\.\\.", ""); // ..
-		returnValue = returnValue.replaceAll("&", "");
+		returnValue = returnValue.replace("/", "");
+		returnValue = returnValue.replace("\\", ""); // \
+		returnValue = returnValue.replace("..", ""); // ..
+		returnValue = returnValue.replace("&", "");
 
 		return returnValue;
 	}
@@ -122,11 +129,14 @@ public class EgovWebUtil {
 			return "";
 		}
 
-		
-		returnValue = returnValue.replaceAll("/", "");
-		returnValue = returnValue.replaceAll("\\..", ""); // ..
-		returnValue = returnValue.replaceAll("\\\\", "");// \
-		returnValue = returnValue.replaceAll("&", "");
+		// 정확성: 기존 정규식 "\\.." 은 주석("// ..")과 달리 '.' + 임의 1문자를 의미해
+		// report.txt -> reportxt 처럼 정상 파일명을 훼손했다. 또한 구분자를 나중에 제거하면
+		// ".\." 같은 입력이 ".." 로 되살아난다. filePathReplaceAll 과 동일하게
+		// 구분자(/,\)를 먼저 제거한 뒤 문자 그대로의 ".." 을 제거한다.
+		returnValue = returnValue.replace("/", "");
+		returnValue = returnValue.replace("\\", ""); // \
+		returnValue = returnValue.replace("..", ""); // ..
+		returnValue = returnValue.replace("&", "");
 
 		return returnValue;
 	}
@@ -136,21 +146,18 @@ public class EgovWebUtil {
 	}
 
 	public static boolean isIPAddress(String str) {
-		Pattern ipPattern = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
-
-		return ipPattern.matcher(str).matches();
+		return IP_PATTERN.matcher(str).matches();
     }
 
 	public static String removeCRLF(String parameter) {
-		return parameter.replaceAll("\r", "").replaceAll("\n", "");
+		return parameter.replace("\r", "").replace("\n", "");
 	}
 
 	public static String removeSQLInjectionRisk(String parameter) {
-		return parameter.replaceAll("\\p{Space}", "").replaceAll("\\*", "").replaceAll("%", "").replaceAll(";", "").replaceAll("-", "").replaceAll("\\+", "").replaceAll(",", "");
+		return SPACE_PATTERN.matcher(parameter).replaceAll("").replace("*", "").replace("%", "").replace(";", "").replace("-", "").replace("+", "").replace(",", "");
 	}
 
 	public static String removeOSCmdRisk(String parameter) {
-		return parameter.replaceAll("\\p{Space}", "").replaceAll("\\*", "").replaceAll("\\|", "").replaceAll(";", "");
+		return SPACE_PATTERN.matcher(parameter).replaceAll("").replace("*", "").replace("|", "").replace(";", "");
 	}
-
 }


### PR DESCRIPTION
## 수정 사유
- [X] 버그수정 (정확성 결함 2건)
- [X] 성능 개선 (정규식 반복 컴파일 제거)

`EgovWebUtil`(파일 다운로드 컨트롤러 등 15곳에서 호출되는 보안 유틸)에서 **성능 1건 + 정확성 결함 2건**을 한 파일에서 정리했습니다.

## 문제 (재현)

**A. 성능** — XSS 필터·경로 검증 메서드가 요청 파라미터마다 `String.replaceAll`로 **정규식을 재컴파일**합니다. `clearXSSMinimum` 1회에 `Pattern.compile`이 8회 일어납니다.

**B. 정확성 ① — clearXSSMaximum의 NPE**: `replaceAll("%00", null)` — replacement에 **null**을 넘겨, 입력에 %00이 포함되면 NullPointerException이 납니다("%00" 제거가 의도). 매치가 없으면 null이 평가되지 않아 지금까지 드러나지 않은 잠복 버그입니다.

**C. 정확성 ② — fileInjectPathReplaceAll의 파일명 훼손**: 정규식 `"\\.."`은 주석("// ..")과 달리 **'.' + 임의 1문자**를 의미해 report.txt → reportxt, photo.png → photong 처럼 정상 파일명을 훼손합니다. 또한 구분자를 나중에 제거해 .\. 같은 입력이 .. 로 되살아납니다.

## 수정

1. **성능**: 정규식 의미 없는 치환은 `String.replace`로, 실제 정규식(\p{Space}·IP)은 `static final Pattern` 호이스팅
2. **B**: `replaceAll("%00", null)` → `replace("%00", "")`
3. **C**: 같은 클래스의 filePathReplaceAll과 동일하게 **구분자(/, \)를 먼저 제거한 뒤 문자 그대로의 ".." 제거**

## 검증 (JDK 17.0.19)

**1) 동작 동일성** — 수정 전/후 클래스를 나란히 두고 경계 21종 + 랜덤 2,000건(총 2,021입력 × 8메서드 = **16,168 콜**) 대조: **동일 15,482 / 버그수정 의도차이 686 / 회귀(비의도 차이) 0**. "회귀 0"이라 성능 리팩터링은 동작을 안 바꿨고, 686건 차이는 전부 버그 수정 지점입니다.

**2) 버그 수정 실증**:
- clearXSSMaximum("a%00b") : old=NPE → new="ab"
- fileInjectPathReplaceAll("report.txt") : old="reportxt" → new="report.txt"
- fileInjectPathReplaceAll(".\\.") : old="." → new=""

**3) 성능** (리플렉션 하네스라 상대비교, 보수적): clearXSSMaximum x8.9 / clearXSSMinimum x3.7 / fileInjectPathReplaceAll x3.4 / removeSQLInjectionRisk x2.5 / 그 외 x1.9~2.3. 재현 하네스는 요청 시 첨부하겠습니다.

## 영향

- 파일 업로드·다운로드 검증 경로의 정확성 회복(NPE·파일명 훼손 제거) + CPU/객체 생성 부담 감소
- 공개 API 시그니처·정상 입력 반환값 불변 (위 동일성 검증)
- 변경 범위: EgovWebUtil.java 1개 파일 (+39 −32)

참고: 동일 유틸이 common-components(#1170·#1156)에도 있어 같은 개선을 진행 중입니다.