### PR TITLE
fix: 이미지 미리보기 MIME 타입 및 스트리밍 처리 개선

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
@@ -1,11 +1,11 @@
 package egovframework.com.cmm.web;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Map;
 
 import jakarta.annotation.Resource;
@@ -120,39 +120,30 @@ public class EgovImageProcessController extends HttpServlet {
 		
 		// Try-with-resources를 이용한 자원 해제 처리 (try 구문에 선언한 리소스를 자동 반납)
 		// try에 전달할 수 있는 자원은 java.lang.AutoCloseable 인터페이스의 구현 객체로 한정
-		try (FileInputStream fis = new FileInputStream(file);
-		     BufferedInputStream in = new BufferedInputStream(fis);
-		     ByteArrayOutputStream bStream = new ByteArrayOutputStream();) {
-			
-			int imgByte;
-			while ((imgByte = in.read()) != -1) {
-				bStream.write(imgByte);
-			}
-
-			String type = "";
-
-			if (fvo.getFileExtsn() != null && !"".equals(fvo.getFileExtsn())) {
-				if ("jpg".equals(fvo.getFileExtsn().toLowerCase())) {
-					type = "image/jpeg";
-				} else {
-					type = "image/" + fvo.getFileExtsn().toLowerCase();
-				}
-				type = "image/" + fvo.getFileExtsn().toLowerCase();
-
-			} else {
-				log.debug("Image fileType is null.");
-			}
-
-			response.setHeader("Content-Type", type);
-			response.setContentLength(bStream.size());
-
-			bStream.writeTo(response.getOutputStream());
-
-			response.getOutputStream().flush();
-			response.getOutputStream().close();
+		try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
+			response.setContentType(getImageContentType(fvo.getFileExtsn()));
+			response.setContentLengthLong(file.length());
+			in.transferTo(response.getOutputStream());
+			response.flushBuffer();
 
 		} catch (IOException e) {
 			log.debug("{}", e);
 		}
+	}
+
+	private String getImageContentType(String fileExtsn) {
+		if (fileExtsn == null || fileExtsn.isBlank()) {
+			log.debug("Image fileType is null.");
+			return "application/octet-stream";
+		}
+
+		return switch (fileExtsn.toLowerCase(Locale.ROOT)) {
+			case "jpg", "jpeg" -> "image/jpeg";
+			case "png" -> "image/png";
+			case "gif" -> "image/gif";
+			case "bmp" -> "image/bmp";
+			case "webp" -> "image/webp";
+			default -> "application/octet-stream";
+		};
 	}
 }

--- a/src/test/java/egovframework/com/cmm/web/EgovImageProcessControllerTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovImageProcessControllerTest.java
@@ -1,0 +1,67 @@
+package egovframework.com.cmm.web;
+
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.FileVO;
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EgovImageProcessControllerTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @DisplayName("JPG 미리보기는 image/jpeg MIME 타입과 원본 바이트를 응답한다.")
+    @Test
+    void getImageInfReturnsJpegContentTypeAndFileBytes() throws Exception {
+        // given
+        byte[] imageBytes = "test-image-bytes".getBytes(StandardCharsets.UTF_8);
+        String storedFileName = "preview.jpg";
+        Files.write(temporaryDirectory.resolve(storedFileName), imageBytes);
+
+        EgovFileMngService fileService = mock(EgovFileMngService.class);
+        EgovCryptoService cryptoService = mock(EgovCryptoService.class);
+        EgovImageProcessController controller = new EgovImageProcessController();
+        ReflectionTestUtils.setField(controller, "fileService", fileService);
+        ReflectionTestUtils.setField(controller, "cryptoService", cryptoService);
+
+        FileVO fileInfo = new FileVO();
+        fileInfo.setFileStreCours(temporaryDirectory.toString());
+        fileInfo.setStreFileNm(storedFileName);
+        fileInfo.setFileExtsn("JPG");
+
+        byte[] encryptedFileId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
+        String encodedFileId = Base64.getEncoder().encodeToString(encryptedFileId);
+        EgovFileDownloadController.ALGORITM_KEY = "test-key";
+        when(cryptoService.decrypt(eq(encryptedFileId), eq("test-key")))
+                .thenReturn("file-id".getBytes(StandardCharsets.UTF_8));
+        when(fileService.selectFileInf(any(FileVO.class))).thenReturn(fileInfo);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        controller.getImageInf(null, new ModelMap(), Map.of("atchFileId", encodedFileId, "fileSn", "0"), response);
+
+        // then
+        assertEquals("image/jpeg", response.getContentType());
+        assertEquals(imageBytes.length, response.getContentLength());
+        assertArrayEquals(imageBytes, response.getContentAsByteArray());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- JPG 확장자의 `image/jpeg` MIME 타입이 `image/jpg`로 다시 덮어써지던 문제를 수정했습니다.
- 확장자별 MIME 타입을 `switch`로 명시적으로 처리하고, 알 수 없는 확장자는 `application/octet-stream`으로 응답합니다.
- 파일 전체를 `ByteArrayOutputStream`에 적재하던 방식을 제거하고, 입력 스트림에서 HTTP 응답 스트림으로 직접 전송하도록 변경했습니다.
- `setContentLengthLong()`을 사용해 큰 파일도 올바른 길이로 응답합니다.
- JPG MIME 타입과 원본 바이트 응답을 검증하는 JUnit 회귀 테스트를 추가했습니다.


## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

<img width="563" height="86" alt="test-result" src="https://github.com/user-attachments/assets/8c1fa741-d382-4cf1-99e2-d9c69ccd1064" />

