### PR TITLE
fix(SnsUtils): 외부 SNS OpenAPI 호출 connect/read 타임아웃 설정 (무응답 무한 블록 방지, CWE-400)

### DIFF
--- a/src/main/java/egovframework/com/sns/SnsUtils.java
+++ b/src/main/java/egovframework/com/sns/SnsUtils.java
@@ -48,7 +48,12 @@ public class SnsUtils {
 	private static HttpURLConnection connect(String apiUrl){
         try {
             URL url = new URL(apiUrl);
-            return (HttpURLConnection)url.openConnection();
+            HttpURLConnection con = (HttpURLConnection)url.openConnection();
+            // 안정성: 외부 SNS OpenAPI 무응답 시 로그인 스레드가 무한 대기하지 않도록
+            // connect/read 타임아웃을 설정한다(CWE-400 자원 고갈 방지).
+            con.setConnectTimeout(5000);
+            con.setReadTimeout(30000);
+            return con;
         } catch (MalformedURLException e) {
             throw new RuntimeException("API URL이 잘못되었습니다. : " + apiUrl, e);
         } catch (IOException e) {


### PR DESCRIPTION
## 요약
SNS 로그인 공통 유틸 `SnsUtils`가 외부 SNS OpenAPI(네이버·카카오 등 프로필/토큰)를 **타임아웃 없이** 호출합니다. 제공자 무응답 시 로그인 요청 스레드가 무한 대기하는 **CWE-400 자원 고갈**을 수정합니다.

## 문제 (재현)
`connect()`가 `url.openConnection()`을 타임아웃 설정 없이 반환하고, `getOpenApi()`가 `getResponseCode()`/`getInputStream()`으로 응답을 읽습니다. `SnsLoginApiController`(202·214·319·330행)의 로그인 흐름에서 사용됩니다.
`HttpURLConnection`은 기본 connect/read 타임아웃이 0(무한)이라, SNS 서버가 응답하지 않으면 요청 처리 스레드가 영구 블록됩니다.
- 재현(소켓 레벨, 무응답 서버 모사): 타임아웃 미설정은 3초 관찰에도 **무한 블록**, 설정 시 `SocketTimeoutException`으로 3초에 복귀.

## 수정
`connect()`에서 `openConnection()` 직후 타임아웃을 설정합니다(connect 5s / read 30s).
```java
HttpURLConnection con = (HttpURLConnection)url.openConnection();
con.setConnectTimeout(5000);
con.setReadTimeout(30000);
return con;
```

## 검증
- 소켓 레벨 재현 하네스로 무한 블록 → 타임아웃 복귀 확인.
- `javac` 컴파일 통과. 공개 메서드 시그니처·호출부 불변(+6 / −1).

## 영향 범위
- 예외 처리 경로 동일. 타임아웃 값(5s/30s)은 보수적 기본값이며 운영 정책에 맞춰 조정 가능합니다.
- 로그인 경로의 스레드 고갈(다수 사용자 로그인 시 연쇄 지연) 예방이 목적입니다.