### PR TITLE
refactor: 단일 스레드 유틸리티의 StringBuffer를 StringBuilder로 변경

### DIFF
--- a/src/main/java/egovframework/com/cmm/filter/HTMLTagFilterRequestWrapper.java
+++ b/src/main/java/egovframework/com/cmm/filter/HTMLTagFilterRequestWrapper.java
@@ -34,7 +34,7 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
 		
 		for (int i = 0; i < values.length; i++) {			
 			if (values[i] != null) {				
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				for (int j = 0; j < values[i].length(); j++) {
 					char c = values[i].charAt(j);
 					switch (c) {
@@ -75,7 +75,7 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
 			return null;
 		}
 		
-		StringBuffer strBuff = new StringBuffer();
+		StringBuilder strBuff = new StringBuilder();
 
 		for (int i = 0; i < value.length(); i++) {
 			char c = value.charAt(i);

--- a/src/main/java/egovframework/com/cmm/web/EgovFileDownloadController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovFileDownloadController.java
@@ -134,7 +134,7 @@ public class EgovFileDownloadController {
 		} else if (browser.equals("Opera")) {
 			encodedFilename = "\"" + new String(filename.getBytes("UTF-8"), "8859_1") + "\"";
 		} else if (browser.equals("Chrome")) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < filename.length(); i++) {
 				char c = filename.charAt(i);
 				if (c > '~') {

--- a/src/main/java/egovframework/let/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovNumberUtil.java
@@ -169,7 +169,7 @@ public class EgovNumberUtil {
 		String subject = String.valueOf(cnvrSrcNumber);
 		String object = String.valueOf(cnvrTrgtNumber);
 
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 

--- a/src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java
@@ -195,7 +195,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replace(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -218,7 +218,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열 / source 특정문자열이 없는 경우 원본 문자열
 	 */
 	public static String replaceOnce(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		if (source.indexOf(subject) >= 0) {
@@ -240,7 +240,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replaceChar(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -472,7 +472,7 @@ public class EgovStringUtil {
 	public static String checkHtmlView(String strString) {
 		String strNew = "";
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = strString.length();
@@ -794,7 +794,7 @@ public class EgovStringUtil {
 
 		String rtnStr = null;
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = srcString.length();


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source


단일 스레드 환경에서 사용되는 유틸리티 클래스의 `StringBuffer`를 `StringBuilder`로 변경했습니다.

`StringBuffer`는 모든 메서드가 `synchronized`로 동기화되어 있어 멀티스레드 환경을 위한 클래스입니다. 
그러나 대상 코드들은 모두 메서드 지역 변수로만 사용되어 여러 스레드가 공유하지 않으므로 동기화가 불필요합니다. 
이 경우 Java 5부터 도입된 `StringBuilder`(비동기) 사용이 표준 권장 방식이므로, 동기화 오버헤드를 제거하고 최신 코드 관례에 맞추었습니다.

**변경 범위 (4개 파일, 9개 선언 지점)**

| 파일 | 지점 |
| --- | --- |
| `EgovStringUtil.java` | 5 |
| `HTMLTagFilterRequestWrapper.java` | 2 |
| `EgovNumberUtil.java` | 1 |
| `EgovFileDownloadController.java` | 1 |

**안전성**
- 대상 인스턴스는 전부 메서드 지역 변수이며, 필드·static 변수·메서드 반환 타입·파라미터로 노출된 곳이 없어 스레드 간 공유가 없습니다.
- 사용된 메서드(`append`, `toString`, `setLength`)는 `StringBuilder`에 동일하게 존재하고 동작이 같아, API 시그니처 및 호출부에 영향이 없습니다. (기능 변화 없음)


**참고한 내용**
- Oracle Java 공식 문서 (`StringBuilder`): "이 클래스는 `StringBuffer`를 대체하도록 설계되었으며, 단일 스레드가 사용하는 경우(일반적인 경우) `StringBuffer`보다 빠릅니다." — https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/StringBuilder.html
- 본 저장소 내에서 이미 다수 파일이 `StringBuilder`를 사용 중이며(예: `EgovStringUtil.java` 내부 기존 코드), 본 변경은 이러한 기존 관례와의 일관성을 맞춥니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

> 본 변경은 백엔드 문자열 유틸리티의 내부 구현 리팩터링으로, 브라우저 UI와 무관하여 JUnit 단위 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

<img width="1376" height="282" alt="스크린샷 2026-07-26 오후 12 32 53" src="https://github.com/user-attachments/assets/81996a24-c853-4311-8d6d-51cf25aa7933" />

`mvn clean test` 결과 셀레니움 E2E 테스트를 제외한 123개 테스트가 모두 통과했습니다. 셀레니움 E2E 테스트(`TestEgovLoginApiControllerSelenium`)는 프론트엔드 서버(localhost:3000) 실행이 필요하여 백엔드 단독 환경에서는 제외했으며, 본 변경(문자열 유틸리티 내부 구현)과는 무관합니다.