### PR TITLE
refactor: 애플리케이션 시작 시 멀티파트 확장자 whitelist를 주입하도록 변경

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovMultipartResolver.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovMultipartResolver.java
@@ -23,7 +23,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 
-import egovframework.com.cmm.service.EgovProperties;
 import egovframework.let.utl.fcc.service.EgovFileUploadUtil;
 import lombok.extern.slf4j.Slf4j;
 
@@ -50,7 +49,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class EgovMultipartResolver extends StandardServletMultipartResolver {
 
-	public EgovMultipartResolver() {
+	private final String whiteListFileUploadExtensions;
+
+	public EgovMultipartResolver(String whiteListFileUploadExtensions) {
+		this.whiteListFileUploadExtensions = whiteListFileUploadExtensions;
 	}
 
 	/**
@@ -61,8 +63,6 @@ public class EgovMultipartResolver extends StandardServletMultipartResolver {
 		MultipartHttpServletRequest multipartRequest = super.resolveMultipart(request);
 		
 		// 확장자 제한 검증
-		String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
-		
 		if (whiteListFileUploadExtensions != null && !"".equals(whiteListFileUploadExtensions)) {
 			Iterator<String> fileNames = multipartRequest.getFileNames();
 			

--- a/src/main/java/egovframework/com/config/EgovConfigAppCommon.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppCommon.java
@@ -133,14 +133,15 @@ public class EgovConfigAppCommon {
 	 * - spring.servlet.multipart.max-request-size=100MB
 	 */
 	@Bean
-	EgovMultipartResolver localMultiCommonsMultipartResolver() {
-		EgovMultipartResolver egovMultipartResolver = new EgovMultipartResolver();
-		return egovMultipartResolver;
+	EgovMultipartResolver localMultiCommonsMultipartResolver(
+			@Value("${Globals.fileUpload.Extensions}") String whiteListFileUploadExtensions) {
+		return new EgovMultipartResolver(whiteListFileUploadExtensions);
 	}
 	
 	@Bean
-	MultipartResolver multipartResolver() {
-		return localMultiCommonsMultipartResolver();
+	MultipartResolver multipartResolver(
+			@Value("${Globals.fileUpload.Extensions}") String whiteListFileUploadExtensions) {
+		return localMultiCommonsMultipartResolver(whiteListFileUploadExtensions);
 	}
 	
 	/**

--- a/src/test/java/egovframework/com/cmm/web/EgovMultipartResolverTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovMultipartResolverTest.java
@@ -1,0 +1,43 @@
+package egovframework.com.cmm.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPart;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+class EgovMultipartResolverTest {
+
+    @Test
+    @DisplayName("주입된 화이트리스트에 포함된 확장자는 멀티파트 요청으로 해석한다.")
+    void resolveMultipartAllowsExtensionInInjectedWhitelist() {
+        EgovMultipartResolver resolver = new EgovMultipartResolver(".png");
+
+        MultipartHttpServletRequest result = resolver.resolveMultipart(multipartRequest("profile.png"));
+
+        assertThat(result.getFile("file")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("주입된 화이트리스트에 없는 확장자는 거부한다.")
+    void resolveMultipartRejectsExtensionOutsideInjectedWhitelist() {
+        EgovMultipartResolver resolver = new EgovMultipartResolver(".png");
+
+        assertThatThrownBy(() -> resolver.resolveMultipart(multipartRequest("payload.exe")))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("File extension not allowed");
+    }
+
+    private MockHttpServletRequest multipartRequest(String filename) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/files");
+        request.setContentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+        request.addPart(new MockPart("file", filename, "content".getBytes(StandardCharsets.UTF_8)));
+        return request;
+    }
+}

--- a/src/test/java/egovframework/com/config/EgovConfigAppCommonTest.java
+++ b/src/test/java/egovframework/com/config/EgovConfigAppCommonTest.java
@@ -1,0 +1,52 @@
+package egovframework.com.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPart;
+
+import egovframework.com.cmm.web.EgovMultipartResolver;
+
+class EgovConfigAppCommonTest {
+
+    @Test
+    @DisplayName("Multipart Resolver 빈 생성 시 전달받은 확장자 화이트리스트를 사용한다.")
+    void localMultiCommonsMultipartResolverUsesConfiguredWhitelist() {
+        EgovConfigAppCommon configuration = new EgovConfigAppCommon();
+        EgovMultipartResolver resolver = configuration.localMultiCommonsMultipartResolver(".webp");
+
+        assertThat(resolver.resolveMultipart(multipartRequest("banner.webp")).getFile("file")).isNotNull();
+        assertThatThrownBy(() -> resolver.resolveMultipart(multipartRequest("banner.png")))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("File extension not allowed");
+    }
+
+    @Test
+    @DisplayName("Multipart Resolver 화이트리스트는 기본값 없이 명시된 설정값을 사용한다.")
+    void multipartResolverWhitelistRequiresExplicitConfiguration() throws NoSuchMethodException {
+        assertThat(whitelistValueOf("localMultiCommonsMultipartResolver").value())
+                .isEqualTo("${Globals.fileUpload.Extensions}");
+        assertThat(whitelistValueOf("multipartResolver").value())
+                .isEqualTo("${Globals.fileUpload.Extensions}");
+    }
+
+    private Value whitelistValueOf(String methodName) throws NoSuchMethodException {
+        Method factoryMethod = EgovConfigAppCommon.class.getDeclaredMethod(methodName, String.class);
+        return factoryMethod.getParameters()[0].getAnnotation(Value.class);
+    }
+
+    private MockHttpServletRequest multipartRequest(String filename) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/files");
+        request.setContentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+        request.addPart(new MockPart("file", filename, "content".getBytes(StandardCharsets.UTF_8)));
+        return request;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- Globals.fileUpload.Extensions 설정을 런타임 조회에서 생성자 주입 방식으로 변경하여 요청마다 프로퍼티를 조회하지 않고 주입된 설정을 재사용하도록 개선했습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
<img width="838" height="443" alt="스크린샷 2026-07-28 오후 6 30 18" src="https://github.com/user-attachments/assets/13b7b085-7620-4e23-b476-45f329dbc564" />

