### PR TITLE
fix: 일정 삭제 시 첨부파일이 사용중 상태로 남는 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/service/impl/EgovIndvdlSchdulManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/service/impl/EgovIndvdlSchdulManageServiceImpl.java
@@ -8,6 +8,8 @@ import jakarta.annotation.Resource;
 import org.springframework.stereotype.Service;
 
 import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.FileVO;
 import egovframework.let.cop.smt.sim.service.EgovIndvdlSchdulManageService;
 import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
 
@@ -36,6 +38,10 @@ public class EgovIndvdlSchdulManageServiceImpl extends EgovAbstractServiceImpl i
 
 	@Resource(name="deptSchdulManageIdGnrService")
 	private EgovIdGnrService idgenService;
+
+
+	@Resource(name="EgovFileMngService")
+	private EgovFileMngService fileService;
 
 
     /**
@@ -129,11 +135,21 @@ public class EgovIndvdlSchdulManageServiceImpl extends EgovAbstractServiceImpl i
 
     /**
 	 * 일정를(을) 삭제한다.
+	 * 일정에 등록된 첨부파일도 함께 삭제 처리한다.
 	 * @param indvdlSchdulManageVO - 조회할 정보가 담긴 VO
 	 * @throws Exception
 	 */
 	@Override
 	public void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
+		IndvdlSchdulManageVO schdulDetail = dao.selectIndvdlSchdulManageDetail(indvdlSchdulManageVO);
+		String atchFileId = (schdulDetail == null) ? null : schdulDetail.getAtchFileId();
+
 		dao.deleteIndvdlSchdulManage(indvdlSchdulManageVO);
+
+		if (atchFileId != null && !atchFileId.trim().isEmpty()) {
+			FileVO fvo = new FileVO();
+			fvo.setAtchFileId(atchFileId);
+			fileService.deleteAllFileInf(fvo);
+		}
 	}
 }

--- a/src/test/java/egovframework/let/cop/smt/sim/service/impl/EgovIndvdlSchdulManageServiceImplTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/service/impl/EgovIndvdlSchdulManageServiceImplTest.java
@@ -1,0 +1,78 @@
+package egovframework.let.cop.smt.sim.service.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+/**
+ * [일정관리][EgovIndvdlSchdulManageServiceImpl.deleteIndvdlSchdulManage] 단위 테스트
+ *
+ * 일정을 삭제할 때 해당 일정에 달린 첨부파일도 함께 정리되는지 확인한다.
+ */
+class EgovIndvdlSchdulManageServiceImplTest {
+
+	private EgovIndvdlSchdulManageServiceImpl newService(IndvdlSchdulManageDao dao, EgovFileMngService fileService) {
+		EgovIndvdlSchdulManageServiceImpl service = new EgovIndvdlSchdulManageServiceImpl();
+		ReflectionTestUtils.setField(service, "dao", dao);
+		ReflectionTestUtils.setField(service, "fileService", fileService);
+		return service;
+	}
+
+	@DisplayName("첨부파일이 있는 일정을 삭제하면 첨부파일도 함께 삭제된다.")
+	@Test
+	void deleteIndvdlSchdulManageRemovesAttachedFile() throws Exception {
+		// given
+		IndvdlSchdulManageDao dao = mock(IndvdlSchdulManageDao.class);
+		EgovFileMngService fileService = mock(EgovFileMngService.class);
+
+		IndvdlSchdulManageVO schdulDetail = new IndvdlSchdulManageVO();
+		schdulDetail.setAtchFileId("FILE_000000000000001");
+		when(dao.selectIndvdlSchdulManageDetail(any(IndvdlSchdulManageVO.class))).thenReturn(schdulDetail);
+
+		IndvdlSchdulManageVO param = new IndvdlSchdulManageVO();
+		param.setSchdulId("SCHDUL_00000000000001");
+
+		// when
+		newService(dao, fileService).deleteIndvdlSchdulManage(param);
+
+		// then
+		verify(dao).deleteIndvdlSchdulManage(param);
+
+		ArgumentCaptor<FileVO> captor = ArgumentCaptor.forClass(FileVO.class);
+		verify(fileService).deleteAllFileInf(captor.capture());
+		org.junit.jupiter.api.Assertions.assertEquals("FILE_000000000000001", captor.getValue().getAtchFileId());
+	}
+
+	@DisplayName("첨부파일이 없는 일정을 삭제하면 파일 삭제는 호출되지 않는다.")
+	@Test
+	void deleteIndvdlSchdulManageSkipsFileRemovalWhenNoAttachment() throws Exception {
+		// given
+		IndvdlSchdulManageDao dao = mock(IndvdlSchdulManageDao.class);
+		EgovFileMngService fileService = mock(EgovFileMngService.class);
+
+		IndvdlSchdulManageVO schdulDetail = new IndvdlSchdulManageVO();
+		schdulDetail.setAtchFileId("");
+		when(dao.selectIndvdlSchdulManageDetail(any(IndvdlSchdulManageVO.class))).thenReturn(schdulDetail);
+
+		IndvdlSchdulManageVO param = new IndvdlSchdulManageVO();
+		param.setSchdulId("SCHDUL_00000000000002");
+
+		// when
+		newService(dao, fileService).deleteIndvdlSchdulManage(param);
+
+		// then
+		verify(dao).deleteIndvdlSchdulManage(param);
+		verify(fileService, never()).deleteAllFileInf(any(FileVO.class));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 한 줄 요약

일정을 삭제할 때 그 일정에 달려 있던 첨부파일을 정리하지 않아, 삭제된 일정의 첨부가 파일 조회에 계속 나옵니다. 게시판은 같은 상황에서 첨부를 정리하고 있어, 두 도메인의 동작이 어긋난 상태입니다.

### 1. 파일 서비스가 삭제를 처리하는 방식

이 템플릿의 파일 서비스는 첨부파일을 실제로 지우지 않습니다. `LETTNFILE` 테이블의 `USE_AT` 컬럼을 `'Y'`에서 `'N'`으로 바꾸는 **논리 삭제** 방식입니다. 레코드와 디스크 파일은 그대로 두고 플래그만 내립니다.

이 플래그는 목록·상세 조회에서 실제로 사용됩니다.

| statement | `USE_AT = 'Y'` 필터 | 위치 |
|---|:---:|---|
| `FileManageDAO.selectFileList` | 있음 | `EgovFile_SQL_mysql.xml:43` |
| `FileManageDAO.selectFileListByFileNm` | 있음 | `EgovFile_SQL_mysql.xml:118` |
| `FileManageDAO.selectFileListCntByFileNm` | 있음 | `EgovFile_SQL_mysql.xml:141` |
| `FileManageDAO.selectImageFileList` | 있음 | `EgovFile_SQL_mysql.xml:165` |
| `FileManageDAO.selectFileInf` | **없음** | `EgovFile_SQL_mysql.xml:86` |

따라서 `'N'`으로 내려간 첨부는 위 네 곳의 조회 결과에서 빠지고, `'Y'`로 남아 있으면 계속 조회됩니다.

**다만 마지막 `selectFileInf`는 예외입니다.** 이 statement는 `LETTNFILEDETAIL`만 읽고 `USE_AT`이 있는 `LETTNFILE`을 참조하지 않아 플래그의 영향을 받지 않습니다. `EgovFileDownloadController:197`과 `EgovImageProcessController:113`이 이 경로를 사용합니다. 즉 **이 PR의 수정으로 첨부가 목록·상세 조회에서 사라지지만, 이미 발급된 다운로드 URL을 직접 호출하는 경로까지 차단되지는 않습니다.** 그쪽은 게시판 첨부도 동일한 상태이므로 이 PR과 별개 건으로 보고 손대지 않았습니다.

위 표는 mysql 매퍼를 기준으로 적었습니다만, 특정 DB에서만 나타나는 문제가 아닙니다. 이 템플릿은 `Globals.DbType` 설정에 따라 DB별 매퍼 XML을 골라 로딩하는데, 지원 대상 6종(mysql · oracle · tibero · cubrid · altibase · hsql) **모두 같은 위치에 같은 필터를 갖고 있습니다.**

그리고 `LETTNFILE`의 이 값을 `'N'`으로 바꾸는 코드는 `EgovFileMngService#deleteAllFileInf` 하나뿐입니다. (다른 테이블에는 별도의 `USE_AT` UPDATE가 있으나 파일 도메인과 무관합니다.)

```java
// FileManageDAO.java
public void deleteAllFileInf(FileVO fvo) throws Exception {
    update("FileManageDAO.deleteCOMTNFILE", fvo);
}
```

```xml
<!-- EgovFile_SQL_mysql.xml:100 -->
<update id="FileManageDAO.deleteCOMTNFILE" parameterType="FileVO">
    UPDATE LETTNFILE
    SET USE_AT = 'N'
    WHERE ATCH_FILE_ID = #{atchFileId}
</update>
```

정리하면, **본체를 삭제하는 쪽에서 `deleteAllFileInf`를 호출해 주지 않으면 그 첨부는 영영 `'Y'` 상태로 남습니다.**

### 2. 같은 파일 서비스를 쓰는 두 도메인의 동작이 다릅니다

게시판은 게시글을 지울 때 첨부를 함께 정리합니다.

```java
// EgovBBSManageServiceImpl 의 deleteBoardArticle 메서드
String atchFileId = bbsDeleteBoardRequestDTO.getAtchFileId();
BoardVO vo = bbsDeleteBoardRequestDTO.toBoardMaster(bbsDeleteBoardRequestDTO, user.getUniqId());

bbsMngDAO.deleteBoardArticle(vo);

if (atchFileId != null && !atchFileId.trim().isEmpty()) {
    FileVO fvo = new FileVO();
    fvo.setAtchFileId(atchFileId);
    fileService.deleteAllFileInf(fvo);
}
```

반면 일정은 일정 레코드만 지우고 끝납니다.

```java
// EgovIndvdlSchdulManageServiceImpl 의 deleteIndvdlSchdulManage 메서드
public void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
    dao.deleteIndvdlSchdulManage(indvdlSchdulManageVO);
}
```

해당 DAO가 실행하는 SQL도 일정 테이블만 지웁니다.

```xml
<!-- EgovIndvdlSchdulManage_SQL_mysql.xml:214 -->
<delete id="deleteIndvdlSchdulManage">
    DELETE FROM LETTNSCHDULINFO WHERE SCHDUL_ID = #{schdulId};
</delete>
```

`LETTNSCHDULINFO` 행이 사라지면 그 행이 들고 있던 `ATCH_FILE_ID`를 참조하는 곳이 없어집니다. 그런데 그 첨부는 `USE_AT = 'Y'` 상태로 남아 있으므로, 위 조회 statement 4곳에 계속 걸립니다.

### 3. 일정 첨부는 실제로 쓰이는 기능입니다

매퍼에 컬럼만 있고 실제로는 사용하지 않는 필드가 아닙니다. 일정 API 세 곳이 첨부를 다루고 있습니다.

- **등록** — `EgovIndvdlSchdulManageApiController:184-191`에서 `multiRequest.getFileMap()`으로 업로드를 받아 `fileUtil.parseFileInf(files, "DSCH_", ...)` → `fileMngService.insertFileInfs()`로 저장하고, 발급받은 ID를 `setAtchFileId()`로 넣습니다.
- **상세 조회** — 같은 컨트롤러 `:259-267`에서 첨부 목록을 읽어 다운로드용 토큰까지 만들어 내려줍니다.
- **수정** — `:353-375`에서 기존 `atchFileId`가 있으면 `getMaxFileSN` 이후 `updateFileInfs`로 파일을 이어붙입니다.

즉 일정에 파일을 올리고, 조회하고, 추가할 수 있습니다. 지우는 경로만 정리를 하지 않습니다.

### 4. 수정 내용

게시판과 같은 방식으로 첨부를 정리하도록 했습니다. 다만 한 가지 차이가 있습니다.

게시판은 삭제 요청 DTO에 `atchFileId`가 함께 넘어옵니다. 반면 일정 삭제 API는 경로 변수로 `schdulId` 하나만 받습니다.

```java
@DeleteMapping(value = "/schedule/{schdulId}")
public ResultVO EgovIndvdlSchdulManageDelete(@PathVariable("schdulId") String schdulId) throws Exception {
    IndvdlSchdulManageVO indvdlSchdulManageVO = new IndvdlSchdulManageVO();
    indvdlSchdulManageVO.setSchdulId(schdulId);
    egovIndvdlSchdulManageService.deleteIndvdlSchdulManage(indvdlSchdulManageVO);
    ...
}
```

그래서 삭제하기 전에 기존 조회 메서드로 `atchFileId`를 먼저 가져오도록 했습니다. `selectIndvdlSchdulManageDetail`이 사용하는 statement는 `A.ATCH_FILE_ID`를 SELECT 목록에 포함하고 있고, resultMap에도 `atchFileId`가 매핑돼 있어 그대로 쓸 수 있습니다.

결과적으로 이 PR은 클라이언트가 보낸 `atchFileId`가 아니라 **서버가 `schdulId`로 조회한 값**만 사용합니다. 임의의 첨부 ID가 삭제 대상으로 지정될 여지가 없습니다.

```java
public void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
    IndvdlSchdulManageVO schdulDetail = dao.selectIndvdlSchdulManageDetail(indvdlSchdulManageVO);
    String atchFileId = (schdulDetail == null) ? null : schdulDetail.getAtchFileId();

    dao.deleteIndvdlSchdulManage(indvdlSchdulManageVO);

    if (atchFileId != null && !atchFileId.trim().isEmpty()) {
        FileVO fvo = new FileVO();
        fvo.setAtchFileId(atchFileId);
        fileService.deleteAllFileInf(fvo);
    }
}
```

세부 사항은 다음과 같습니다.

- `atchFileId`의 null·공백 검사는 게시판 구현과 같은 조건을 사용했습니다.
- 이미 삭제된 일정에 삭제 요청이 다시 들어오는 경우를 위해 조회 결과가 `null`인지 먼저 확인합니다.
- 삭제 순서(본체 먼저, 첨부 정리 나중)도 게시판과 동일하게 맞췄습니다.
- `EgovFileMngService` 주입은 이 클래스가 기존에 쓰던 `@Resource` 방식을 그대로 따랐습니다.

**트랜잭션** — 일정 DELETE와 첨부 UPDATE는 한 트랜잭션으로 묶입니다. `EgovConfigAppTransaction:89-93`의 포인트컷이 `egovframework.let..impl.*Impl.*`와 `egovframework.com..*Impl.*`를 모두 잡아 `EgovIndvdlSchdulManageServiceImpl`과 `EgovFileMngServiceImpl`이 함께 걸리고, 전파는 `REQUIRED`, 롤백 규칙은 `Exception.class`입니다. 첨부 정리가 실패하면 일정 삭제도 롤백됩니다.

**기존 statement 재사용에 따른 트레이드오프** — `selectIndvdlSchdulManageDetailVO`는 조직명·담당자명을 위한 상관 서브쿼리 2개를 포함하고 있어, `atchFileId` 하나를 얻는 데는 과한 조회입니다. 그럼에도 `ATCH_FILE_ID`만 뽑는 statement를 새로 만들면 DB 6종 매퍼를 모두 수정해야 하므로, 변경 범위를 최소화하는 쪽을 택했습니다. 삭제 요청당 SELECT 1회가 추가됩니다.

### 5. 영향 범위

- 운영 코드 변경은 `EgovIndvdlSchdulManageServiceImpl.java` 하나이며 16줄이 추가되고 삭제된 줄은 없습니다. 나머지 한 파일은 새로 추가한 테스트입니다.
- 매퍼 XML, API 시그니처, 기존 호출부는 바뀌지 않았습니다.
- 첨부가 없는 일정을 삭제하는 경우에는 `atchFileId`가 비어 있어 기존과 완전히 동일하게 동작합니다.
- [#182](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/182)가 같은 파일을 포함하고 있으나, 그쪽은 메서드 시그니처에서 `throws Exception`을 제거하는 변경이고 이 PR은 메서드 본문에 로직을 추가하는 변경이라 서로 독립적입니다. 현재 이 PR은 충돌 없이 병합 가능한 상태입니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

JDK 17 환경에서 확인했습니다.

- `mvn compile` — 통과했습니다.
- `mvn clean test` — 126건 모두 통과했습니다. 기존 124건에 이 PR에서 2건을 더했습니다.

프론트엔드(`egovframe-template-simple-react`)를 `localhost:3000`에 함께 띄운 상태에서 측정했습니다. 이 저장소의 `TestEgovLoginApiControllerSelenium`은 실제 화면을 거쳐 로그인하는 테스트라 프론트엔드가 떠 있어야 통과합니다.

### 추가한 테스트

`EgovIndvdlSchdulManageServiceImplTest`를 새로 추가했습니다. 두 가지를 확인합니다.

- 첨부파일이 있는 일정을 삭제하면, 그 일정이 들고 있던 `ATCH_FILE_ID`로 파일 삭제가 호출된다
- 첨부파일이 없는 일정을 삭제하면, 파일 삭제가 호출되지 않는다

기존 코드에서는 이 테스트가 통과하지 않습니다. `EgovIndvdlSchdulManageServiceImpl`에 파일 서비스 참조 자체가 없어 주입 단계에서 멈춥니다.

```
java.lang.IllegalArgumentException: Could not find field 'fileService'
  on target class [EgovIndvdlSchdulManageServiceImpl]
```

같은 파일 서비스를 쓰는 게시판 쪽은 이미 첨부를 정리하고 있으므로, 이 테스트는 두 도메인의 동작을 같은 기준으로 맞춰 두는 역할도 합니다.

### 데이터 계층 확인

테스트가 확인하는 것은 호출 여부까지입니다. 실제로 `USE_AT`이 바뀌는지는 내장 HSQL(`Globals.DbType=hsql`, `EmbeddedDatabaseBuilder` + `db/shtdb.sql`) 환경에서 별도로 대조했습니다.

1. `LETTNFILE`에 `USE_AT = 'Y'`인 첨부 행을 넣습니다.
2. 그 `ATCH_FILE_ID`를 가진 일정 행을 `LETTNSCHDULINFO`에 넣습니다.
3. `EgovIndvdlSchdulManageService#deleteIndvdlSchdulManage`를 호출합니다.
4. 일정 행 수와 첨부의 `USE_AT`을 조회합니다.

| | 삭제 전 `USE_AT` | 삭제 후 일정 행 수 | 삭제 후 `USE_AT` |
|---|---|---|---|
| 수정 전 | `Y` | 0 | **`Y`** |
| 수정 후 | `Y` | 0 | **`N`** |

두 경우 모두 일정 행은 정상적으로 삭제됩니다. 차이는 첨부의 `USE_AT`뿐입니다.

애플리케이션 기동(`mvn spring-boot:run`) 후 HTTP로도 동일한 흐름을 확인했습니다. `POST /schedule`에 파일을 첨부해 등록하면 `LETTNFILE`에 `USE_AT = 'Y'`로 행이 생성됩니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서비스 계층의 백엔드 로직만 변경했고 화면이나 응답 형식은 그대로여서, 브라우저에 따라 달라지는 동작이 없습니다. 그래서 별도로 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다.




