### PR TITLE
fix: 논리 삭제된 첨부파일이 다운로드·이미지 조회로 계속 반환되는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovFileDownloadController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovFileDownloadController.java
@@ -196,6 +196,11 @@ public class EgovFileDownloadController {
 			fileVO.setFileSn(fileSn);
 			FileVO fvo = fileService.selectFileInf(fileVO);
 
+			// 삭제 처리된(USE_AT='N') 첨부는 조회되지 않으므로 파일 없음과 동일하게 처리한다
+			if (fvo == null) {
+				throw new EgovBizException();
+			}
+
 			String fileStreCours = EgovWebUtil.filePathBlackList(fvo.getFileStreCours());
 			String streFileNm = EgovWebUtil.filePathBlackList(fvo.getStreFileNm());
 

--- a/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
@@ -114,7 +114,7 @@ public class EgovImageProcessController extends HttpServlet {
 
 		// 삭제 처리된(USE_AT='N') 첨부는 조회되지 않으므로 파일 없음과 동일하게 처리한다
 		if (fvo == null) {
-			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
 			return;
 		}
 

--- a/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
@@ -112,6 +112,12 @@ public class EgovImageProcessController extends HttpServlet {
 
 		FileVO fvo = fileService.selectFileInf(vo);
 
+		// 삭제 처리된(USE_AT='N') 첨부는 조회되지 않으므로 파일 없음과 동일하게 처리한다
+		if (fvo == null) {
+			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+			return;
+		}
+
 		//String fileLoaction = fvo.getFileStreCours() + fvo.getStreFileNm();
 		String fileStreCours = EgovWebUtil.filePathBlackList(fvo.getFileStreCours());
 		String streFileNm = EgovWebUtil.filePathBlackList(fvo.getStreFileNm());

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_altibase.xml
@@ -86,14 +86,18 @@
  	<select id="selectFileInf" parameterType="FileVO" resultMap="fileDetail">
  		
 			SELECT 
-				ATCH_FILE_ID, FILE_CN, FILE_SN, FILE_STRE_COURS, STRE_FILE_NM,
-				FILE_EXTSN, ORIGNL_FILE_NM, FILE_SIZE
+				b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
+				b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
 			FROM
-				LETTNFILEDETAIL
+				LETTNFILE a, LETTNFILEDETAIL b
 			WHERE
-				ATCH_FILE_ID = #{atchFileId}
+				b.ATCH_FILE_ID = #{atchFileId}
 			AND 
-				FILE_SN = #{fileSn}	
+				b.FILE_SN = #{fileSn}	
+			AND 
+				a.ATCH_FILE_ID = b.ATCH_FILE_ID
+			AND 
+				a.USE_AT = 'Y'
  		
  	</select>
 

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_cubrid.xml
@@ -86,14 +86,18 @@
  	<select id="FileManageDAO.selectFileInf" parameterType="FileVO" resultMap="fileDetail">
  		
 			SELECT 
-				ATCH_FILE_ID, FILE_CN, FILE_SN, FILE_STRE_COURS, STRE_FILE_NM,
-				FILE_EXTSN, ORIGNL_FILE_NM, FILE_SIZE
+				b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
+				b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
 			FROM
-				LETTNFILEDETAIL
+				LETTNFILE a, LETTNFILEDETAIL b
 			WHERE
-				ATCH_FILE_ID = #{atchFileId}
+				b.ATCH_FILE_ID = #{atchFileId}
 			AND 
-				FILE_SN = #{fileSn}	
+				b.FILE_SN = #{fileSn}	
+			AND 
+				a.ATCH_FILE_ID = b.ATCH_FILE_ID
+			AND 
+				a.USE_AT = 'Y'
  		
  	</select>
 

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_hsql.xml
@@ -86,14 +86,18 @@
  	<select id="FileManageDAO.selectFileInf" parameterType="FileVO" resultMap="fileDetail">
  		
 			SELECT 
-				ATCH_FILE_ID, FILE_CN, FILE_SN, FILE_STRE_COURS, STRE_FILE_NM,
-				FILE_EXTSN, ORIGNL_FILE_NM, FILE_SIZE
+				b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
+				b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
 			FROM
-				LETTNFILEDETAIL
+				LETTNFILE a, LETTNFILEDETAIL b
 			WHERE
-				ATCH_FILE_ID = #{atchFileId}
+				b.ATCH_FILE_ID = #{atchFileId}
 			AND 
-				FILE_SN = #{fileSn}	
+				b.FILE_SN = #{fileSn}	
+			AND 
+				a.ATCH_FILE_ID = b.ATCH_FILE_ID
+			AND 
+				a.USE_AT = 'Y'
  		
  	</select>
 

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_mysql.xml
@@ -86,14 +86,18 @@
  	<select id="FileManageDAO.selectFileInf" parameterType="FileVO" resultMap="fileDetail">
  		
 			SELECT 
-				ATCH_FILE_ID, FILE_CN, FILE_SN, FILE_STRE_COURS, STRE_FILE_NM,
-				FILE_EXTSN, ORIGNL_FILE_NM, FILE_SIZE
+				b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
+				b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
 			FROM
-				LETTNFILEDETAIL
+				LETTNFILE a, LETTNFILEDETAIL b
 			WHERE
-				ATCH_FILE_ID = #{atchFileId}
+				b.ATCH_FILE_ID = #{atchFileId}
 			AND 
-				FILE_SN = #{fileSn}	
+				b.FILE_SN = #{fileSn}	
+			AND 
+				a.ATCH_FILE_ID = b.ATCH_FILE_ID
+			AND 
+				a.USE_AT = 'Y'
  		
  	</select>
 

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_oracle.xml
@@ -86,14 +86,18 @@
  	<select id="FileManageDAO.selectFileInf" parameterType="FileVO" resultMap="fileDetail">
  		
 			SELECT 
-				ATCH_FILE_ID, FILE_CN, FILE_SN, FILE_STRE_COURS, STRE_FILE_NM,
-				FILE_EXTSN, ORIGNL_FILE_NM, FILE_SIZE
+				b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
+				b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
 			FROM
-				LETTNFILEDETAIL
+				LETTNFILE a, LETTNFILEDETAIL b
 			WHERE
-				ATCH_FILE_ID = #{atchFileId}
+				b.ATCH_FILE_ID = #{atchFileId}
 			AND 
-				FILE_SN = #{fileSn}	
+				b.FILE_SN = #{fileSn}	
+			AND 
+				a.ATCH_FILE_ID = b.ATCH_FILE_ID
+			AND 
+				a.USE_AT = 'Y'
  		
  	</select>
 

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_tibero.xml
@@ -86,14 +86,18 @@
  	<select id="FileManageDAO.selectFileInf" parameterType="FileVO" resultMap="fileDetail">
  		
 			SELECT 
-				ATCH_FILE_ID, FILE_CN, FILE_SN, FILE_STRE_COURS, STRE_FILE_NM,
-				FILE_EXTSN, ORIGNL_FILE_NM, FILE_SIZE
+				b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
+				b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
 			FROM
-				LETTNFILEDETAIL
+				LETTNFILE a, LETTNFILEDETAIL b
 			WHERE
-				ATCH_FILE_ID = #{atchFileId}
+				b.ATCH_FILE_ID = #{atchFileId}
 			AND 
-				FILE_SN = #{fileSn}	
+				b.FILE_SN = #{fileSn}	
+			AND 
+				a.ATCH_FILE_ID = b.ATCH_FILE_ID
+			AND 
+				a.USE_AT = 'Y'
  		
  	</select>
 

--- a/src/test/java/egovframework/com/cmm/service/impl/FileManageDAOTest.java
+++ b/src/test/java/egovframework/com/cmm/service/impl/FileManageDAOTest.java
@@ -1,0 +1,70 @@
+package egovframework.com.cmm.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import egovframework.com.cmm.service.FileVO;
+
+/**
+ * [파일관리][FileManageDAO.selectFileInf] DAO 단위 테스트
+ *
+ * 첨부파일 마스터(LETTNFILE)는 USE_AT 플래그로 논리 삭제된다.
+ * 삭제 처리된 첨부가 상세 조회에서 걸러지는지 확인한다.
+ */
+@SpringBootTest
+@Transactional
+class FileManageDAOTest {
+
+	@Autowired
+	private FileManageDAO fileManageDAO;
+
+	private FileVO newFile(String atchFileId) {
+		FileVO vo = new FileVO();
+		vo.setAtchFileId(atchFileId);
+		vo.setFileSn("0");
+		vo.setFileStreCours("./files");
+		vo.setStreFileNm("TEST_20260803000000000");
+		vo.setOrignlFileNm("sample.png");
+		vo.setFileExtsn("png");
+		vo.setFileMg("1024");
+		vo.setFileCn("");
+		return vo;
+	}
+
+	@DisplayName("사용 중인 첨부파일은 상세 정보가 조회된다.")
+	@Test
+	void selectFileInfReturnsFileInUse() throws Exception {
+		// given
+		FileVO vo = newFile("FILE_TEST0000000001");
+		fileManageDAO.insertFileInf(vo);
+
+		// when
+		FileVO result = fileManageDAO.selectFileInf(vo);
+
+		// then
+		assertNotNull(result, "USE_AT='Y'인 첨부파일은 조회되어야 한다.");
+		assertEquals("sample.png", result.getOrignlFileNm());
+	}
+
+	@DisplayName("삭제 처리된 첨부파일은 상세 정보가 조회되지 않는다.")
+	@Test
+	void selectFileInfExcludesDeletedFile() throws Exception {
+		// given
+		FileVO vo = newFile("FILE_TEST0000000002");
+		fileManageDAO.insertFileInf(vo);
+
+		// when
+		fileManageDAO.deleteAllFileInf(vo);
+		FileVO result = fileManageDAO.selectFileInf(vo);
+
+		// then
+		assertNull(result, "USE_AT='N'으로 삭제된 첨부파일은 조회되지 않아야 한다.");
+	}
+}

--- a/src/test/java/egovframework/com/cmm/web/EgovImageProcessControllerTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovImageProcessControllerTest.java
@@ -2,6 +2,8 @@ package egovframework.com.cmm.web;
 
 import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.com.cmm.service.FileVO;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.egovframe.rte.fdl.crypto.EgovCryptoService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,5 +65,32 @@ class EgovImageProcessControllerTest {
         assertEquals("image/jpeg", response.getContentType());
         assertEquals(imageBytes.length, response.getContentLength());
         assertArrayEquals(imageBytes, response.getContentAsByteArray());
+    }
+
+    @DisplayName("삭제 처리되어 조회되지 않는 첨부는 404 를 응답한다.")
+    @Test
+    void getImageInfReturnsNotFoundWhenFileIsNotAvailable() throws Exception {
+        // given
+        EgovFileMngService fileService = mock(EgovFileMngService.class);
+        EgovCryptoService cryptoService = mock(EgovCryptoService.class);
+        EgovImageProcessController controller = new EgovImageProcessController();
+        ReflectionTestUtils.setField(controller, "fileService", fileService);
+        ReflectionTestUtils.setField(controller, "cryptoService", cryptoService);
+
+        byte[] encryptedFileId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
+        String encodedFileId = Base64.getEncoder().encodeToString(encryptedFileId);
+        EgovFileDownloadController.ALGORITM_KEY = "test-key";
+        when(cryptoService.decrypt(eq(encryptedFileId), eq("test-key")))
+                .thenReturn("file-id".getBytes(StandardCharsets.UTF_8));
+        when(fileService.selectFileInf(any(FileVO.class))).thenReturn(null);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        controller.getImageInf(null, new ModelMap(), Map.of("atchFileId", encodedFileId, "fileSn", "0"), response);
+
+        // then
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        assertEquals(0, response.getContentAsByteArray().length);
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 한 줄 요약

`deleteAllFileInf`로 논리 삭제한 첨부파일이 다운로드(`GET /file`)와 이미지 조회(`GET /image`)로는 계속 반환됩니다. 두 경로가 사용하는 `FileManageDAO.selectFileInf`에 `USE_AT` 필터가 없기 때문입니다.

### 1. 첨부파일은 두 테이블에 나뉘어 저장됩니다

```sql
-- DATABASE/all_sht_ddl_mysql.sql:265
CREATE TABLE LETTNFILE (          -- 첨부 묶음
  ATCH_FILE_ID char(20) NOT NULL,
  CREAT_DT     datetime NOT NULL,
  USE_AT       char(1),           -- 논리 삭제 플래그
  PRIMARY KEY (ATCH_FILE_ID)
);

-- DATABASE/all_sht_ddl_mysql.sql:274
CREATE TABLE LETTNFILEDETAIL (    -- 개별 파일
  ATCH_FILE_ID    char(20) NOT NULL,
  FILE_SN         decimal(10,0) NOT NULL,
  FILE_STRE_COURS varchar(2000) NOT NULL,   -- 저장 경로
  STRE_FILE_NM    varchar(255) NOT NULL,    -- 저장 파일명
  ...
  PRIMARY KEY (ATCH_FILE_ID, FILE_SN),
  CONSTRAINT LETTNFILEDETAIL_ibfk_1 FOREIGN KEY (ATCH_FILE_ID) REFERENCES LETTNFILE (ATCH_FILE_ID)
);
```

`USE_AT`은 `LETTNFILE`에만 있습니다. 따라서 `LETTNFILEDETAIL`만 조회하는 statement는 해당 첨부가 삭제 처리됐는지 판단할 수 없습니다.

### 2. 조회 경로에 따라 필터 적용 여부가 다릅니다

목록 조회는 두 테이블을 조인해 플래그를 확인합니다.

```sql
-- FileManageDAO.selectFileList (EgovFile_SQL_mysql.xml:31, main 기준)
FROM   LETTNFILE a, LETTNFILEDETAIL b
WHERE  a.ATCH_FILE_ID = #{atchFileId}
AND    a.ATCH_FILE_ID = b.ATCH_FILE_ID
AND    a.USE_AT = 'Y'
```

반면 다운로드 조회는 `LETTNFILEDETAIL`만 읽습니다.

```sql
-- FileManageDAO.selectFileInf (EgovFile_SQL_mysql.xml:86, main 기준) — 수정 전
FROM   LETTNFILEDETAIL
WHERE  ATCH_FILE_ID = #{atchFileId}
AND    FILE_SN = #{fileSn}
```

`USE_AT = 'Y'` 필터를 가진 statement와 그렇지 않은 statement는 다음과 같습니다.

| statement | `USE_AT` 필터 | 사용처 |
|---|:---:|---|
| `FileManageDAO.selectFileList` | 있음 | 첨부 목록 조회 |
| `FileManageDAO.selectFileListByFileNm` | 있음 | 파일명 검색 |
| `FileManageDAO.selectFileListCntByFileNm` | 있음 | 파일명 검색 건수 |
| `FileManageDAO.selectImageFileList` | 있음 | 이미지 목록 |
| `FileManageDAO.selectFileInf` | **없음** | `EgovFileDownloadController:197`, `EgovImageProcessController:113` |

표의 행 번호는 `main` 기준입니다. 아래 수정 내용의 가드 행 번호는 이 PR 적용 후 기준입니다.

지원 DB 6종(mysql · oracle · tibero · cubrid · altibase · hsql) 매퍼가 모두 동일한 상태였습니다.

### 3. 논리 삭제가 무력화됩니다

`deleteAllFileInf`가 실행하는 SQL은 `LETTNFILE`의 플래그만 내립니다.

```sql
-- FileManageDAO.deleteCOMTNFILE (EgovFile_SQL_mysql.xml:100, main 기준)
UPDATE LETTNFILE SET USE_AT = 'N' WHERE ATCH_FILE_ID = #{atchFileId}
```

`LETTNFILEDETAIL` 행과 디스크 파일은 그대로 남습니다. 다운로드에 필요한 `FILE_STRE_COURS`(경로)와 `STRE_FILE_NM`(파일명)이 모두 유지되므로, `selectFileInf`가 필터 없이 조회하면 파일이 정상 반환됩니다.

결과적으로 첨부는 목록·상세 조회에서는 사라지지만, 삭제 이전에 발급된 다운로드 URL로는 그대로 받을 수 있습니다.

현재 `main`에서 `deleteAllFileInf`를 호출하는 곳은 `EgovBBSManageServiceImpl:73`(게시글 삭제) 하나입니다. 일정 삭제에도 같은 호출을 추가하는 #183이 함께 반영되면 그쪽에도 동일하게 적용됩니다.

### 4. 수정 내용

`selectFileInf`가 `LETTNFILE`을 조인해 `USE_AT`을 확인하도록 했습니다. 같은 파일의 `selectFileList`가 이미 사용하는 방식과 동일한 형태로 맞췄습니다.

```sql
-- 수정 후
SELECT b.ATCH_FILE_ID, b.FILE_CN, b.FILE_SN, b.FILE_STRE_COURS, b.STRE_FILE_NM,
       b.FILE_EXTSN, b.ORIGNL_FILE_NM, b.FILE_SIZE
FROM   LETTNFILE a, LETTNFILEDETAIL b
WHERE  b.ATCH_FILE_ID = #{atchFileId}
AND    b.FILE_SN = #{fileSn}
AND    a.ATCH_FILE_ID = b.ATCH_FILE_ID
AND    a.USE_AT = 'Y'
```

DB 6종 매퍼에 동일하게 반영했습니다. 같은 성격의 변경이므로 하나의 PR로 묶었습니다.

**호출부의 null 처리를 함께 추가했습니다.** 두 컨트롤러는 `selectFileInf`의 반환값을 바로 역참조하고 있었습니다.

이 null 경로는 이 PR이 새로 만든 것이 아니라 **현재 `main`에서 이미 도달 가능합니다.** `EgovFileMngApiController:112`의 개별 첨부 삭제(`POST /file`)가 `deleteFileInf` → `FileManageDAO.deleteFileDetail`로 `DELETE FROM LETTNFILEDETAIL`을 실행해 상세 행을 하드 삭제하기 때문입니다. 그 뒤 같은 `atchFileId`·`fileSn`으로 `GET /file`이나 `GET /image`를 호출하면 `selectFileInf`가 `null`을 반환하고 `fvo.getFileStreCours()`에서 `NullPointerException`이 발생합니다.

`main`에서 확인한 결과입니다.

```
삭제 전 조회 = 찾음
하드삭제 후 LETTNFILEDETAIL 행 = 0
하드삭제 후 조회 = null   → 컨트롤러가 역참조하면 NPE
```

따라서 이번 가드는 필터 추가에 따른 부산물이 아니라 **기존 NPE 경로까지 함께 닫는 변경**입니다.

```java
// EgovFileDownloadController:201 — 기존 "파일 없음" 처리와 동일하게 EgovBizException
if (fvo == null) {
    throw new EgovBizException();
}
```

```java
// EgovImageProcessController:117 — HttpServletResponse 를 직접 다루는 컨트롤러이므로 404
if (fvo == null) {
    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
    return;
}
```

`sendError` 대신 `setStatus`를 사용했습니다. `sendError`는 checked `IOException`을 던지는데, #182가 이 메서드의 `throws Exception`을 제거하고 있어 두 변경이 함께 반영되면 컴파일이 실패합니다. 두 헝크의 위치가 떨어져 있어 git 텍스트 충돌로는 드러나지 않습니다. `setStatus`는 checked exception이 없어 머지 순서와 무관하게 컴파일됩니다. 로컬에서 [#182](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/182) 패치를 적용한 상태로 컴파일해 확인했습니다.

### 5. 영향 범위

- 운영 코드는 매퍼 6개 + 컨트롤러 2개, 총 8파일 (+65 −30). 여기에 테스트 2파일이 더해집니다
- 삭제되지 않은 첨부(`USE_AT = 'Y'`)의 다운로드·이미지 조회 동작은 변하지 않습니다
- `LETTNFILEDETAIL` 행과 디스크 파일은 삭제하지 않습니다. 조회에서만 제외됩니다
- 인증 정책(`SecurityConfig`의 `/file`·`/image` 화이트리스트)은 건드리지 않았습니다. 별개 판단이 필요한 영역으로 보았습니다
- `[#176](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/176)`(PostgreSQL 지원 추가)이 머지되면 `EgovFile_SQL_postgres.xml`에도 동일한 필터가 필요합니다
- `[#182](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/182)`가 같은 메서드의 `throws Exception`을 제거합니다. 위 `setStatus` 선택으로 머지 순서에 관계없이 컴파일되도록 맞췄습니다

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17, 내장 HSQL(`Globals.DbType=hsql`) 환경에서 확인했습니다.

- `mvn compile` — 통과했습니다.
- `mvn clean test` — 127건 모두 통과했습니다. 기존 124건에 이 PR에서 3건을 더했습니다.

프론트엔드(`egovframe-template-simple-react`)를 `localhost:3000`에 함께 띄운 상태에서 측정했습니다. 이 저장소의 `TestEgovLoginApiControllerSelenium`은 실제 화면을 거쳐 로그인하는 테스트라 프론트엔드가 떠 있어야 통과합니다.

### 추가한 테스트

수정한 두 계층을 각각 확인하는 테스트를 넣었습니다.

**`FileManageDAOTest`** — 매퍼 SQL 자체를 확인합니다. 내장 HSQL에 첨부 마스터와 상세 행을 넣고, `deleteAllFileInf`로 `USE_AT`을 `N`으로 바꾼 뒤 `selectFileInf`를 다시 호출합니다. 사용 중인 첨부는 조회되고 삭제 처리된 첨부는 조회되지 않아야 합니다.

**`EgovImageProcessControllerTest`** — 이미 있던 테스트에 케이스를 하나 더했습니다. `selectFileInf`가 결과를 돌려주지 않을 때 미리보기가 404로 응답하고 본문을 쓰지 않는지 확인합니다.

두 테스트 모두 수정 전 코드에서는 통과하지 않습니다. `main`에 테스트만 얹어 돌린 결과입니다.

```
FileManageDAOTest.selectFileInfExcludesDeletedFile
  USE_AT='N'으로 삭제된 첨부파일은 조회되지 않아야 한다.
  ==> expected: <null> but was: <FileVO[atchFileId=FILE_TEST0000000002,
                                        fileStreCours=./files, streFileNm=TEST_20260803000000000]>

EgovImageProcessControllerTest.getImageInfReturnsNotFoundWhenFileIsNotAvailable
  NullPointer: Cannot invoke "FileVO.getFileStreCours()" because "fvo" is null
```

두 번째 오류가 본문 앞에서 설명한 기존 `NullPointerException` 경로입니다. 이 PR의 가드가 그 경로도 함께 닫습니다.

### 데이터가 지워지지는 않습니다

위 DAO 테스트에서 논리 삭제 전후로 `LETTNFILEDETAIL` 행 수는 1개로 유지됩니다. 데이터를 삭제하는 변경이 아니라 조회에서 제외하는 변경입니다.

| | 삭제 전 조회 | 삭제 후 `USE_AT` | 삭제 후 조회 | `LETTNFILEDETAIL` 행 수 |
|---|---|---|---|---|
| 수정 전 | 찾음 | `N` | **찾음** | 1 |
| 수정 후 | 찾음 | `N` | **null** | 1 |

테스트는 `hsql` 매퍼를 통해 돕니다. 나머지 5종 매퍼는 같은 위치에 같은 조건을 넣었고 SQL 문법이 동일하나, 실제 DB로 돌려 보지는 못했습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

매퍼 SQL과 서비스 계층 변경이라 브라우저에 따라 달라지는 동작이 없습니다. 그래서 별도로 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다.



