### PR TITLE
build(maven): dependency 중복 선언 제거

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,10 +106,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-jasper</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<optional>true</optional>
@@ -210,11 +206,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 		</dependency>
@@ -288,7 +279,7 @@
 			<version>${icu4j.version}</version>
 		</dependency>
 
-		<!-- CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
+		<!-- CVE-2025-48924/CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-annotations-api</artifactId>
@@ -312,13 +303,6 @@
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-websocket</artifactId>
-			<version>${tomcat-embed.version}</version>
-		</dependency>
-
-		<!-- CVE-2025-48924: 보안취약점 보완용 직접 주입 -->
-		<dependency>
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>tomcat-annotations-api</artifactId>
 			<version>${tomcat-embed.version}</version>
 		</dependency>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

Maven 중복 의존성 제거
- tomcat-embed-jasper
- commons-lang3
- tomcat-annotations-api

> [!NOTE]
> CVE-2025-48924 보안 취약점 대응했던 tomcat-annotations-api 에 대한 주석은 지우지않았습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

- as-is
<img width="1267" height="552" alt="as-is" src="https://github.com/user-attachments/assets/031dabd5-ed9b-43da-96f4-573f6cce4fb6" />

- to-be
<img width="1267" height="552" alt="to-be" src="https://github.com/user-attachments/assets/3822e6de-b4f3-4843-96a4-6b0fcf778c76" />
