### PR TITLE
[머지하지 마세요] CI 점검: 실패하는 테스트가 현재 워크플로를 통과합니다

### DIFF
--- a/src/test/java/egovframework/com/CiProbeFailingTest.java
+++ b/src/test/java/egovframework/com/CiProbeFailingTest.java
@@ -1,0 +1,22 @@
+package egovframework.com;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * CI 검증용 프로브.
+ *
+ * 컴파일은 정상적으로 통과하고 실행 단계에서만 실패한다.
+ * 외부 서비스나 스프링 컨텍스트에 의존하지 않으므로, 이 테스트가 통과했다면
+ * 테스트가 아예 실행되지 않았다는 뜻이다.
+ */
+class CiProbeFailingTest {
+
+    @DisplayName("의도적으로 실패하는 단정 - 테스트가 실행되면 반드시 실패한다")
+    @Test
+    void deliberatelyFails() {
+        assertEquals(1, 2, "이 테스트는 CI가 테스트를 실행하는지 확인하기 위해 의도적으로 실패한다");
+    }
+}


### PR DESCRIPTION
> **이 PR은 머지 요청이 아닙니다.** 현재 CI 워크플로가 테스트 실패를 적발하는지 확인하기 위한 점검용이며, 체크 실행 결과를 확인한 직후 제가 직접 닫겠습니다. 확인된 내용을 근거로 워크플로 수정 PR을 별도로 올릴 예정입니다.

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

기타에 해당합니다. 소스의 결함을 고치는 변경이 아니라, `.github/workflows/maven.yml`이 테스트 실패를 적발하는지 확인하기 위해 검증용 테스트 한 개를 추가한 것입니다.

확인하려는 것은 다음 한 가지입니다. 현재 워크플로의 빌드 단계는 아래와 같이 `-Dmaven.test.skip=true`가 붙어 있습니다.

```yaml
- name: Build with Maven
  run: mvn -B package --file pom.xml -Dmaven.test.skip=true
```

`-DskipTests`는 테스트 실행만 건너뛰고 테스트 소스 컴파일은 수행하지만, `-Dmaven.test.skip=true`는 테스트 컴파일까지 건너뜁니다. 그래서 이 워크플로가 검증하는 범위는 본 소스가 컴파일되고 패키징이 완료되는지까지이고, 테스트가 통과하는지는 검증 대상에 들어가지 않습니다. 문서상 그렇게 읽히는 것과 실제로 그렇게 동작하는 것은 다른 문제이므로, 실패가 보장된 테스트를 넣어 실제 체크 결과로 확인하고자 합니다.

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

`src/test/java/egovframework/com/CiProbeFailingTest.java` 한 개를 추가했습니다. 본 소스는 수정하지 않았습니다.

```java
class CiProbeFailingTest {

    @DisplayName("의도적으로 실패하는 단정 - 테스트가 실행되면 반드시 실패한다")
    @Test
    void deliberatelyFails() {
        assertEquals(1, 2, "이 테스트는 CI가 테스트를 실행하는지 확인하기 위해 의도적으로 실패한다");
    }
}
```

검증 목적에 맞도록 두 가지를 의도했습니다. 첫째, 컴파일은 정상적으로 통과하고 실행 단계에서만 실패합니다. 컴파일 오류로 실패하면 그것은 기존 워크플로도 이미 잡아내는 범위이므로 확인하려는 대상이 달라집니다. 둘째, 스프링 컨텍스트나 데이터베이스, 외부 서비스에 의존하지 않습니다. 그래야 체크가 통과했을 때 그 원인이 환경 문제가 아니라 테스트가 실행되지 않았다는 것으로 좁혀집니다.

파일명은 surefire 기본 include 패턴에 걸리도록 `*Test.java`로 맞췄습니다. 이 저장소 `pom.xml`에는 surefire 설정이 없어 기본 패턴이 적용됩니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

동일한 커밋에서 두 명령을 각각 실행해 대조했습니다. JDK 17, Maven 3.9.9 기준입니다.

먼저 이 테스트가 실제로 실패하는 유효한 테스트인지 확인했습니다.

```
$ mvn -B test -Dtest=CiProbeFailingTest -DfailIfNoSpecifiedTests=false

[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0 -- in egovframework.com.CiProbeFailingTest
org.opentest4j.AssertionFailedError: ... ==> expected: <1> but was: <2>
[INFO] BUILD FAILURE
```

다음으로 워크플로가 실행하는 명령을 그대로 실행했습니다.

```
$ mvn -B package --file pom.xml -Dmaven.test.skip=true

[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ egovframe-boot-simple-backend ---
[INFO] Not compiling test sources
[INFO] --- surefire:3.5.4:test (default-test) @ egovframe-boot-simple-backend ---
[INFO] Tests are skipped.
[INFO] BUILD SUCCESS
```

같은 소스인데 결과가 갈립니다. Maven 로그에 `Not compiling test sources`와 `Tests are skipped`가 그대로 찍히는 것으로 원인이 확인됩니다.

이 PR의 체크 결과가 성공으로 표시되면 위 로컬 결과가 CI에서도 재현된 것입니다. 실패로 표시되면 제가 워크플로를 잘못 읽은 것이므로 그때는 이 PR을 닫고 후속 제안도 철회하겠습니다.

참고로 제가 이전에 올린 [#183](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/183)과 [#184](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/184)에서 추가한 테스트 5건도 현재 설정에서는 CI에서 실행되지 않습니다. 로컬에서는 통과를 확인했으나, 이후 누군가 해당 동작을 되돌려도 CI는 초록불을 유지합니다. 테스트를 추가하는 기여가 회귀 방지로 이어지지 않고 있다는 점이 이 확인을 하게 된 배경입니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

화면과 무관한 변경이라 선택하지 않았습니다. 추가한 파일은 테스트 소스 한 개이고 본 소스와 화면 코드는 수정하지 않았으므로 브라우저에서 확인할 대상이 없습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 확인 결과는 이 PR에 표시되는 Actions 체크 상태와 위 JUnit 절의 명령 출력으로 대조하실 수 있습니다.
