### PR TITLE
ci: 워크플로에서 테스트가 실행되지 않는 문제 수정

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml -Dmaven.test.skip=true
+      # 브라우저가 필요한 browser 태그 테스트는 러너에서 제외한다
+      run: mvn -B package --file pom.xml -DexcludedGroups=browser
     - name: list artifact
       run: ls -laR target

--- a/src/test/java/egovframework/let/uat/uia/web/TestEgovLoginApiControllerSelenium.java
+++ b/src/test/java/egovframework/let/uat/uia/web/TestEgovLoginApiControllerSelenium.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Tag("browser")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class TestEgovLoginApiControllerSelenium {
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

`.github/workflows/maven.yml`의 빌드 명령에 `-Dmaven.test.skip=true`가 붙어 있어 테스트가 실행되지 않고 있습니다. `-DskipTests`는 실행만 건너뛰고 테스트 소스 컴파일은 수행하지만, `-Dmaven.test.skip=true`는 테스트 컴파일까지 건너뜁니다. 그래서 현재 이 워크플로가 검증하는 범위는 본 소스가 컴파일되고 패키징이 완료되는지까지입니다.

문서상 그렇게 읽히는 것과 실제로 그렇게 동작하는 것은 다르므로, 반드시 실패하는 테스트를 넣어 실제 체크 결과를 먼저 확인했습니다. 그 결과가 [#187](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/187)이고, 해당 PR의 체크는 [성공으로 표시](https://github.com/eGovFramework/egovframe-template-simple-backend/actions/runs/30906569067/job/91982919290)되었습니다. 확인이 끝나 그 PR은 닫았습니다.

이 확인을 하게 된 배경은 제가 이전에 올린 [#183](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/183)과 [#184](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/184)입니다. 두 PR에서 추가한 테스트 5건은 논리 삭제된 첨부파일이 다시 조회되지 않는지를 검증하는 것인데, 현재 설정에서는 CI에서 실행되지 않습니다. 이후 누군가 해당 동작을 되돌려도 체크는 초록불을 유지합니다. 테스트를 추가하는 기여가 회귀 방지로 이어지지 않는 상태라고 판단해 워크플로 쪽을 함께 제안드립니다.

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

두 개 파일을 수정했습니다. 본 소스는 수정하지 않았습니다.

첫째, `.github/workflows/maven.yml`의 빌드 명령입니다.

```diff
     - name: Build with Maven
-      run: mvn -B package --file pom.xml -Dmaven.test.skip=true
+      # 브라우저가 필요한 browser 태그 테스트는 러너에서 제외한다
+      run: mvn -B package --file pom.xml -DexcludedGroups=browser
```

둘째, `TestEgovLoginApiControllerSelenium`에 `@Tag("browser")`를 붙였습니다.

```diff
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
+@Tag("browser")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class TestEgovLoginApiControllerSelenium {
```

이 테스트를 제외하는 이유는 러너에서 실제로 확인한 결과입니다. 테스트만 켜고 다른 조치를 하지 않으면 이 테스트 하나 때문에 체크가 실패합니다. 실패 지점은 `setup()`의 `new ChromeDriver()`이고 메시지는 `SessionNotCreated: Chrome instance exited`입니다. 나머지 132건은 전부 통과합니다.

제외 방식으로 세 가지를 검토했고 `excludedGroups`를 골랐습니다.

`-Dtest=!TestEgovLoginApiControllerSelenium`은 한 줄로 끝나지만 surefire의 include 패턴을 대체해 버립니다. 실제로 실행해 보니 기본 패턴에 걸리지 않던 `ProfileTestDev`·`ProfileTestProd`가 함께 실행되어 대상이 133건에서 134건으로 늘었습니다. 제외하려는 변경이 실행 대상을 넓히는 것은 의도와 맞지 않아 제외했습니다.

`pom.xml`의 surefire `<excludes>`에 넣는 방법은 로컬 `mvn test`에서도 이 테스트가 함께 빠집니다. 이 테스트는 브라우저와 프론트엔드 개발 서버가 있으면 정상적으로 동작하므로, 개발자 환경의 검증 범위를 줄이지 않는 편이 낫다고 판단했습니다.

`excludedGroups`는 include 패턴을 건드리지 않고 태그가 붙은 것만 뺍니다. 그리고 명령줄에만 주므로 로컬 `mvn test`의 동작은 그대로입니다. 아래 JUnit 절에 로컬에서 이 테스트가 여전히 실행되는 것을 확인한 결과를 넣었습니다.

`pom.xml`에는 surefire 설정이 없어 기본 include 패턴이 적용되며, 이 변경은 그 패턴을 그대로 둡니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

수정 전과 후를 GitHub Actions 러너에서 각각 돌려 네 가지 조합을 대조했습니다. 반드시 실패하는 테스트는 아래와 같이 컴파일은 통과하고 실행에서만 실패하며, 스프링 컨텍스트나 외부 서비스에 의존하지 않습니다.

```java
@Test
void deliberatelyFails() {
    assertEquals(1, 2, "이 테스트는 CI가 테스트를 실행하는지 확인하기 위해 의도적으로 실패한다");
}
```

| 워크플로 | 트리 | 체크 결과 | 실행 기록 |
|---|---|---|---|
| 수정 전 | 실패하는 테스트 추가 | 성공 | [본 저장소 run](https://github.com/eGovFramework/egovframe-template-simple-backend/actions/runs/30906569067/job/91982919290) |
| 테스트만 활성화 | 변경 없음 | 실패 | [run](https://github.com/masiljangajji/egovframe-template-simple-backend/actions/runs/30906477711) |
| 수정 후 | 변경 없음 | 성공 | [run](https://github.com/masiljangajji/egovframe-template-simple-backend/actions/runs/30906880463) |
| 수정 후 | 실패하는 테스트 추가 | 실패 | [run](https://github.com/masiljangajji/egovframe-template-simple-backend/actions/runs/30906893340) |

첫 행이 현재 상태이고 마지막 행이 이 PR이 의도하는 상태입니다. 두 번째 행은 테스트만 켜면 Chrome 문제로 체크가 실패한다는 것이고, 세 번째 행은 이 수정이 정상 트리를 잘못 실패시키지 않는다는 것입니다. 두 번째와 세 번째 행은 본 저장소에 불필요한 PR을 남기지 않기 위해 제 포크에서 같은 워크플로로 실행했습니다.

네 번째 행의 실패 원인이 의도한 테스트인지 확인했습니다. Chrome 오류는 없습니다.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0 <<< FAILURE! -- in egovframework.com.CiProbeFailingTest
```

로컬 대조입니다. JDK 17, Maven 3.9.9 기준입니다.

```
$ mvn -B package --file pom.xml -DexcludedGroups=browser
[INFO] Tests run: 132, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`excludedGroups`를 주지 않은 로컬 실행에서는 태그를 붙인 뒤에도 이 테스트가 그대로 실행됩니다. 프론트엔드 개발 서버를 `localhost:3000`에 띄우고 확인했습니다.

```
$ mvn -B test -Dtest=TestEgovLoginApiControllerSelenium -DfailIfNoSpecifiedTests=false
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.43 s
[INFO] BUILD SUCCESS
```

측정하지 못한 것을 함께 적습니다. 러너에서 Chrome이 실행되지 않는 원인 자체는 조사하지 않았습니다. `setup-chromedriver` 계열 액션을 추가하고 프론트엔드 개발 서버를 러너에서 함께 띄우면 이 테스트까지 CI에서 검증할 수 있으나, 이 PR의 범위를 테스트 실행 여부로 한정했습니다. 이 부분은 별도로 다루는 편이 검토에 유리하다고 판단했습니다.

러너에서의 워크플로 전체 소요 시간은 테스트 실행이 추가되면서 20초에서 49초로 늘었습니다. 위 표 첫 행과 세 번째 행의 실행 기록을 대조한 값입니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

화면을 바꾸는 변경은 아니지만, 태그를 붙인 대상이 Chrome을 사용하는 Selenium 테스트여서 로컬에서 Chrome으로 해당 테스트가 여전히 실행되는지 확인했습니다. 위 JUnit 절의 마지막 출력이 그 결과입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 수정 전후 대조는 위 표의 네 가지 실행 기록으로 확인하실 수 있습니다. 각 링크에서 Maven 출력과 체크 결과를 직접 보실 수 있습니다.
