### PR TITLE
test(selenium): WebDriver 실행 불가 시 로그인 테스트 건너뛰기

### DIFF
--- a/src/test/java/egovframework/let/uat/uia/web/TestEgovLoginApiControllerSelenium.java
+++ b/src/test/java/egovframework/let/uat/uia/web/TestEgovLoginApiControllerSelenium.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,13 +18,24 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+//@EnabledOnOs(OS.LINUX)
+//@EnabledOnOs(OS.MAC)
+//@EnabledOnOs(OS.WINDOWS)
 class TestEgovLoginApiControllerSelenium {
 
 	WebDriver driver;
 
 	@BeforeEach
 	public void setup() {
-		driver = new ChromeDriver();
+		try {
+			driver = new ChromeDriver();
+//			driver = new EdgeDriver();
+//			driver = new FirefoxDriver();
+//			driver = new InternetExplorerDriver();
+//			driver = new SafariDriver();
+		} catch (WebDriverException e) {
+			Assumptions.abort("WebDriver를 실행할 수 없어 테스트를 건너뜁니다.");
+		}
 	}
 
 	@AfterEach


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

https://github.com/eGovFramework/egovframe-template-simple-backend/pull/188 개선

###  개요

브라우저 또는 WebDriver를 사용할 수 없는 환경에서 Selenium 로그인 테스트가 실패하지 않도록 테스트 초기화 로직을 개선했습니다.

###  변경 내용

- `ChromeDriver` 초기화 중 발생하는 `WebDriverException` 처리
- WebDriver를 실행할 수 없으면 `Assumptions.abort()`를 사용해 테스트 건너뛰기
- Edge, Firefox, Internet Explorer, Safari 드라이버 설정 예시 추가
- OS별 테스트 활성화 어노테이션 예시 추가

###  기대 효과

- WebDriver가 설치되지 않은 개발 및 CI 환경에서 불필요한 테스트 실패 방지
- 실행 환경에 맞는 브라우저 드라이버로 쉽게 전환 가능
- Selenium 테스트의 환경 의존성을 명확하게 처리

###  검증

- [x] `git diff --check` 통과
- [ ] WebDriver와 프런트엔드가 실행 중인 환경에서 Selenium 로그인 테스트 확인

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="스크린샷 2026-08-05 212639" src="https://github.com/user-attachments/assets/056010df-93e3-4be6-adb9-09da7f0174a2" />

https://youtu.be/z584a56cB84


