### PR TITLE
refactor(datasource): 커넥션 풀을 HikariCP로 전환

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<tomcat-embed.version>10.1.52</tomcat-embed.version>
 		<commons-beanutils.version>1.11.0</commons-beanutils.version>
 		<commons-lang3.version>3.18.0</commons-lang3.version>
+		<hikaricp.version>6.3.3</hikaricp.version>
 	</properties>
 
 	<repositories>
@@ -187,8 +188,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-dbcp2</artifactId>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>${hikaricp.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/egovframework/com/config/EgovConfigAppDatasource.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppDatasource.java
@@ -3,7 +3,7 @@ package egovframework.com.config;
 import jakarta.annotation.PostConstruct;
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -70,15 +70,16 @@ public class EgovConfigAppDatasource {
 	}
 
 	/**
-	 * @return [dataSource 설정] basicDataSource 설정
+	 * @return [dataSource 설정] HikariDataSource 설정
 	 */
-	private DataSource basicDataSource() {
-		BasicDataSource basicDataSource = new BasicDataSource();
-		basicDataSource.setDriverClassName(className);
-		basicDataSource.setUrl(url);
-		basicDataSource.setUsername(userName);
-		basicDataSource.setPassword(password);
-		return basicDataSource;
+	private DataSource hikariDataSource() {
+		HikariDataSource hikariDataSource = new HikariDataSource();
+		hikariDataSource.setDriverClassName(className);
+		hikariDataSource.setJdbcUrl(url);
+		hikariDataSource.setUsername(userName);
+		hikariDataSource.setPassword(password);
+		hikariDataSource.setMaximumPoolSize(10);
+		return hikariDataSource;
 	}
 
 	/**
@@ -89,7 +90,7 @@ public class EgovConfigAppDatasource {
 		if ("hsql".equals(dbType)) {
 			return dataSourceHSQL();
 		} else {
-			return basicDataSource();
+			return hikariDataSource();
 		}
 	}
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ㅌ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 개요

데이터베이스 커넥션 풀 구현을 Apache Commons DBCP2에서 HikariCP로 전환합니다.

### 변경 사항

- `commons-dbcp2` 의존성 제거
- `com.zaxxer:HikariCP:6.3.3` 의존성 추가
- `BasicDataSource`를 `HikariDataSource`로 교체
- JDBC URL, 드라이버, 사용자명 및 비밀번호 설정을 HikariCP 방식으로 변경
- 최대 커넥션 풀 크기를 10으로 설정
- 기존 내장 HSQL 데이터소스 구성 유지

### 검증

- JDK 17.0.17 사용
- Maven 3.9.9 사용
- `mvn -DskipTests clean compile` 성공
- 전체 Java 소스 144개 컴파일 성공
- 의존성 트리에서 `com.zaxxer:HikariCP:6.3.3` 적용 확인

### 영향 범위

- HSQL 이외의 데이터베이스 연결이 HikariCP를 사용합니다.
- 데이터소스 Bean 이름과 주입 구조는 변경하지 않습니다.
- 내장 HSQL 환경의 동작은 기존과 동일합니다.

http://localhost:8080/mainPage

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="스크린샷 2026-08-06 093220" src="https://github.com/user-attachments/assets/920453fb-5e1a-4c27-b191-6be985e840a3" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/502b54c6-5441-46a2-a378-7a752f9e660c" />

https://youtu.be/Ni481yd63Ik
