### PR TITLE
Fix/file upload size setting

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -49,8 +49,6 @@ public class EgovFileMngUtil {
 
     public static final int BUFF_SIZE = 2048;
 
-    private static final long MAX_FILE_SIZE = 10L * 1024 * 1024; // 10MB
-    
     @Value("${Globals.fileUpload.Extensions:.gif.jpg.jpeg.png.xls.xlsx}")
     private String allowedExtensionsRaw;
 
@@ -105,6 +103,7 @@ public class EgovFileMngUtil {
 	String filePath = "";
 	List<FileVO> result  = new ArrayList<FileVO>();
 	FileVO fvo;
+	long maxFileSize = propertyService.getLong("Globals.posblAtchFileSize");
 
 	while (itr.hasNext()) {
 	    Entry<String, MultipartFile> entry = itr.next();
@@ -142,8 +141,8 @@ public class EgovFileMngUtil {
 
 	    // 파일 크기 검증
 	    long _size = file.getSize();
-	    if (_size > MAX_FILE_SIZE) {
-	        throw new EgovBizException("파일 크기가 허용 한도(10MB)를 초과했습니다.");
+	    if (_size > maxFileSize) {
+			throw new EgovBizException("파일 크기가 허용 한도(" + maxFileSize + "바이트)를 초과했습니다.");
 	    }
 
 	    // 파일명 정규화 (경로 탈출·제어문자 제거)

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_hsql.xml
@@ -148,7 +148,7 @@
 					b.STRE_FILE_NM LIKE '%' || #{searchWrd} || '%' 		
 			</if>
 			<if test="searchCnd == &quot;orignlFileNm&quot;">AND
-					b.ORIGNL_FILE_NM LIKE '%' || #{searchWrd} '%'  		
+					b.ORIGNL_FILE_NM LIKE '%' || #{searchWrd} || '%'  		
 			</if>	 		
  	</select>
  	

--- a/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
@@ -38,6 +38,7 @@ class EgovFileMngUtilTest {
         ReflectionTestUtils.setField(egovFileMngUtil, "allowedExtensionsRaw", ".gif.jpg.jpeg.png.xls.xlsx");
         ReflectionTestUtils.setField(egovFileMngUtil, "propertyService", propertyService);
         ReflectionTestUtils.setField(egovFileMngUtil, "idgenService", idgenService);
+        when(propertyService.getLong("Globals.posblAtchFileSize")).thenReturn(5L * 1024 * 1024);
     }
 
     @DisplayName("parseFileInf 호출 시, 허용된 확장자의 파일이면 FileVO 목록을 반환한다.")
@@ -93,7 +94,7 @@ class EgovFileMngUtilTest {
 
         MultipartFile multipartFile = mock(MultipartFile.class);
         when(multipartFile.getOriginalFilename()).thenReturn("big.png");
-        when(multipartFile.getSize()).thenReturn(11L * 1024 * 1024);
+        when(multipartFile.getSize()).thenReturn(5L * 1024 * 1024 + 1);
 
         Map<String, MultipartFile> files = new LinkedHashMap<>();
         files.put("file", multipartFile);


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- [EgovFile_SQL_hsql.xml](https://github.com/eGovFramework/egovframe-template-simple-backend/compare/main...ydj515:egovframe-template-simple-backend:fix/file-upload-size-setting?expand=1#diff-5dd2caa63a7eb593ca84442065e064605d148a0bd9619130d88a4ea8006ef56e): searchWrd 뒤에 `||` 누락 수정
- [EgovFileMngUtil.java](https://github.com/eGovFramework/egovframe-template-simple-backend/compare/main...ydj515:egovframe-template-simple-backend:fix/file-upload-size-setting?expand=1#diff-256e0076f13f5fefa79ad432ea5ebc2bcf59416d5c60028c81c29542bc6ebeda): application.properties의 Globals.posblAtchFileSize값과 업로드 제한이 일치하도록 수정(5MB)

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
<img width="561" height="178" alt="test" src="https://github.com/user-attachments/assets/4a0a82e9-05e3-40a6-9b62-1b0695245ee8" />
