### PR TITLE
refactor: jwt 정보를 읽을 때 claims 한번만 파싱하도록 수정

### DIFF
--- a/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
+++ b/src/main/java/egovframework/com/jwt/EgovJwtTokenUtil.java
@@ -62,9 +62,12 @@ public class EgovJwtTokenUtil implements Serializable{
 
 	public String getInfoFromToken(String type, String token) {
 		Claims claims = getClaimFromToken(token);
-	    Object info = claims.get(type);
+		return getInfoFromClaims(type, claims);
+	}
 
-	    return info != null ? info.toString() : null;
+	private String getInfoFromClaims(String type, Claims claims) {
+		Object info = claims.get(type);
+		return info != null ? info.toString() : null;
 	}
 
 	public Claims getClaimFromToken(String token) {
@@ -116,20 +119,21 @@ public class EgovJwtTokenUtil implements Serializable{
 	public LoginVO getLoginVOFromToken(String token) throws InvalidJwtException{
 		LoginVO loginVO = new LoginVO();
 
-        try {
-		    loginVO.setId(getUserIdFromToken(token));
-			loginVO.setName(getInfoFromToken("name", token));
-			loginVO.setUserSe(getUserSeFromToken(token));
-			loginVO.setOrgnztId(getInfoFromToken("orgnztId", token));
-			loginVO.setUniqId(getInfoFromToken("uniqId", token));
-            loginVO.setGroupNm(getInfoFromToken("groupNm", token));
+		try {
+			Claims claims = getClaimFromToken(token);
+			loginVO.setId(getInfoFromClaims("id", claims));
+			loginVO.setName(getInfoFromClaims("name", claims));
+			loginVO.setUserSe(getInfoFromClaims("userSe", claims));
+			loginVO.setOrgnztId(getInfoFromClaims("orgnztId", claims));
+			loginVO.setUniqId(getInfoFromClaims("uniqId", claims));
+			loginVO.setGroupNm(getInfoFromClaims("groupNm", claims));
 
-            if(loginVO.getId() == null) throw new InvalidJwtException("Missing id in token");
-        } catch (IllegalArgumentException e) {
-            throw new InvalidJwtException("Unable to verify JWT Token: " + e.getMessage());
-        } catch (JwtException e) {
-            throw new InvalidJwtException("Unable to verify JWT Token: " + e.getMessage());
-        }
+			if(loginVO.getId() == null) throw new InvalidJwtException("Missing id in token");
+		} catch (IllegalArgumentException e) {
+			throw new InvalidJwtException("Unable to verify JWT Token: " + e.getMessage());
+		} catch (JwtException e) {
+			throw new InvalidJwtException("Unable to verify JWT Token: " + e.getMessage());
+		}
 
 		return loginVO;
 	}

--- a/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
+++ b/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
@@ -1,6 +1,7 @@
 package egovframework.com.jwt;
 
 import egovframework.com.cmm.LoginVO;
+import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,32 @@ class EgovJwtTokenUtilTest {
         assertEquals("ROLE_USER", result.getGroupNm());
     }
 
+    @DisplayName("토큰에서 LoginVO를 생성할 때, JWT를 한 번만 파싱한다.")
+    @Test
+    void testGetLoginVOFromTokenParsesTokenOnlyOnce() {
+        // given
+        CountingJwtTokenUtil countingJwtTokenUtil = new CountingJwtTokenUtil();
+        ReflectionTestUtils.setField(countingJwtTokenUtil, "secretKeyString",
+                ReflectionTestUtils.getField(jwtTokenUtil, "secretKeyString"));
+
+        LoginVO loginVO = new LoginVO();
+        loginVO.setId("testUser");
+        loginVO.setName("Test User");
+        loginVO.setUserSe("USER");
+        loginVO.setOrgnztId("testOrg");
+        loginVO.setUniqId("testUniqId");
+        loginVO.setGroupNm("ROLE_USER");
+
+        String token = countingJwtTokenUtil.generateToken(loginVO);
+
+        // when
+        LoginVO result = countingJwtTokenUtil.getLoginVOFromToken(token);
+
+        // then
+        assertEquals("testUser", result.getId());
+        assertEquals(1, countingJwtTokenUtil.getParseCount());
+    }
+
     @DisplayName("잘못된 토큰을 입력했을 때, InvalidJwtException 예외가 발생한다.")
     @Test
     void testInvalidTokenReturnsThrowException() {
@@ -78,5 +105,19 @@ class EgovJwtTokenUtilTest {
         assertThrows(InvalidJwtException.class, () -> {
             jwtTokenUtil.getLoginVOFromToken(token);
         });
+    }
+
+    private static class CountingJwtTokenUtil extends EgovJwtTokenUtil {
+        private int parseCount;
+
+        @Override
+        public Claims getAllClaimsFromToken(String token) {
+            parseCount++;
+            return super.getAllClaimsFromToken(token);
+        }
+
+        int getParseCount() {
+            return parseCount;
+        }
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- [govJwtTokenUtil.java](https://github.com/eGovFramework/egovframe-template-simple-backend/compare/main...ydj515:feat/jwt-single-parse?expand=1#diff-b1e091bca91c5222cc169b8b6737ae636befcc98aa8c36dd4428e649a0d4eb58): 로그인 정보 필드 6개를 읽을 때마다 토큰 파싱과 서명 검증을 반복하던걸 Claims를 한 번만 파싱해 모든 필드를 구성하고, 파싱 호출 횟수를 줄임

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
<img width="561" height="146" alt="test2" src="https://github.com/user-attachments/assets/c0289961-5b04-491a-bd64-cc3c8a9cc150" />


