### PR TITLE
fix: 게시물 삭제 시 첨부파일 정리에 요청값 대신 저장된 게시물의 첨부 그룹을 사용

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
@@ -65,8 +65,12 @@ public class EgovBBSManageServiceImpl extends EgovAbstractServiceImpl implements
 	 */
 	@Override
 	public void deleteBoardArticle(BbsManageDeleteBoardRequestDTO bbsDeleteBoardRequestDTO, LoginVO user) throws Exception {
-		String atchFileId = bbsDeleteBoardRequestDTO.getAtchFileId();
 		BoardVO vo = bbsDeleteBoardRequestDTO.toBoardMaster(bbsDeleteBoardRequestDTO, user.getUniqId());
+
+		// 첨부파일 그룹은 요청값이 아니라 저장된 게시물에서 읽는다.
+		BoardVO storedArticle = bbsMngDAO.selectBoardArticle(vo);
+		String atchFileId = (storedArticle == null) ? null : storedArticle.getAtchFileId();
+
 		bbsMngDAO.deleteBoardArticle(vo);
 		
 		if (atchFileId != null && !atchFileId.trim().isEmpty()) {

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImplTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImplTest.java
@@ -21,6 +21,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.let.cop.bbs.domain.model.Board;
+import egovframework.let.cop.bbs.dto.request.BbsManageDeleteBoardRequestDTO;
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.LoginVO;
 import egovframework.let.cop.bbs.domain.repository.BBSManageDAO;
 
 @ExtendWith(MockitoExtension.class)
@@ -110,5 +114,54 @@ class EgovBBSManageServiceImplTest {
         // DAO 불리지 않는지 확인
         verify(bbsMngDAO, never()).insertBoardArticle(any());
         verify(bbsMngDAO, never()).replyBoardArticle(any());
+    }
+
+    @Test
+    @DisplayName("게시물 삭제 시 첨부파일 그룹은 클라이언트가 보낸 값이 아니라 저장된 게시물에서 읽는다")
+    void testDeleteBoardArticle_UsesStoredAtchFileId() throws Exception {
+        // given: 저장된 게시물의 첨부는 FILE_STORED 인데 요청은 FILE_FROM_CLIENT 를 보낸다.
+        BoardVO stored = new BoardVO();
+        stored.setAtchFileId("FILE_STORED");
+        when(bbsMngDAO.selectBoardArticle(any(BoardVO.class))).thenReturn(stored);
+
+        BbsManageDeleteBoardRequestDTO request = new BbsManageDeleteBoardRequestDTO();
+        request.setBbsId("BBSMSTR_000000000001");
+        request.setNttId(1L);
+        request.setAtchFileId("FILE_FROM_CLIENT");
+
+        LoginVO user = new LoginVO();
+        user.setUniqId("USRCNFRM_00000000001");
+
+        // when
+        egovBBSManageService.deleteBoardArticle(request, user);
+
+        // then
+        ArgumentCaptor<FileVO> captor = ArgumentCaptor.forClass(FileVO.class);
+        verify(fileService).deleteAllFileInf(captor.capture());
+        assertEquals("FILE_STORED", captor.getValue().getAtchFileId());
+    }
+
+    @Test
+    @DisplayName("요청에 첨부파일 그룹이 비어 있어도 저장된 첨부는 정리된다")
+    void testDeleteBoardArticle_CleansUpWhenRequestOmitsAtchFileId() throws Exception {
+        // given: 요청에는 atchFileId 가 없지만 저장된 게시물에는 첨부가 있다.
+        BoardVO stored = new BoardVO();
+        stored.setAtchFileId("FILE_STORED");
+        when(bbsMngDAO.selectBoardArticle(any(BoardVO.class))).thenReturn(stored);
+
+        BbsManageDeleteBoardRequestDTO request = new BbsManageDeleteBoardRequestDTO();
+        request.setBbsId("BBSMSTR_000000000001");
+        request.setNttId(1L);
+
+        LoginVO user = new LoginVO();
+        user.setUniqId("USRCNFRM_00000000001");
+
+        // when
+        egovBBSManageService.deleteBoardArticle(request, user);
+
+        // then
+        ArgumentCaptor<FileVO> captor = ArgumentCaptor.forClass(FileVO.class);
+        verify(fileService).deleteAllFileInf(captor.capture());
+        assertEquals("FILE_STORED", captor.getValue().getAtchFileId());
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBBSManageServiceImpl.deleteBoardArticle`은 첨부파일 그룹 ID를 요청 DTO에서 그대로 받아 `deleteAllFileInf`에 넘깁니다. 이 값이 타는 SQL에는 소유권 조건이 없습니다.

```xml
<!-- EgovFile_SQL_mysql.xml:104 -->
UPDATE LETTNFILE SET USE_AT = 'N' WHERE ATCH_FILE_ID = #{atchFileId}
```

컨트롤러는 게시물 소유권을 검증하고 `bbsId`·`nttId`·`nttSj`를 path variable로 덮어쓰지만, 정작 파괴적 동작에 쓰이는 `atchFileId`만 요청 본문 값이 그대로 남습니다. 그래서 두 가지가 생깁니다.

1. 요청에서 `atchFileId`를 비우면 분기를 건너뛰어 첨부가 `USE_AT='Y'`로 남습니다.
2. 다른 게시물의 `atchFileId`를 실어 보내면 자기 글을 지우면서 남의 첨부 그룹이 비활성화됩니다. `GET /board/{bbsId}/{nttId}`는 `AUTH_GET_WHITELIST`에 있어 익명 조회가 되고, 응답의 최상위 `atchFileId`는 암호화되지 않은 채 나갑니다(파일 목록 안의 개별 파일 ID만 암호화됩니다).

이 자리는 한 번 손댄 적이 있습니다. `2a67d34`("다른 사용자의 접근 차단 처리")가 컨트롤러에 소유권 검증을 넣으면서 첨부 정리 블록 바로 위에 있던 주석을 지웠는데,

```
-		// 작성자 외 삭제 불가능하도록 기능 개선 필요
```

정작 그 아래 첨부 정리 블록은 그대로 두어 이 경로가 남았습니다.

AS-IS

```java
String atchFileId = bbsDeleteBoardRequestDTO.getAtchFileId();
BoardVO vo = bbsDeleteBoardRequestDTO.toBoardMaster(bbsDeleteBoardRequestDTO, user.getUniqId());
bbsMngDAO.deleteBoardArticle(vo);
```

TO-BE

```java
BoardVO vo = bbsDeleteBoardRequestDTO.toBoardMaster(bbsDeleteBoardRequestDTO, user.getUniqId());

// 첨부파일 그룹은 요청값이 아니라 저장된 게시물에서 읽는다.
BoardVO storedArticle = bbsMngDAO.selectBoardArticle(vo);
String atchFileId = (storedArticle == null) ? null : storedArticle.getAtchFileId();

bbsMngDAO.deleteBoardArticle(vo);
```

형제 모듈이 이미 같은 방식입니다. `deleteIndvdlSchdulManage`(`a20bdb0`)는 요청값을 쓰지 않고 `selectIndvdlSchdulManageDetail`로 서버에서 다시 읽으며, 삭제 전에 조회하는 순서도 같습니다.

컨트롤러가 소유권 검증을 위해 이미 조회한 값을 재사용하지 않고 서비스에서 다시 읽는 이유는 두 조회의 목적이 다르기 때문입니다. 컨트롤러의 조회는 "이 사용자가 지워도 되는가"를 묻고, 서비스의 조회는 "무엇이 실제로 저장돼 있는가"를 묻습니다. 후자를 호출자가 준 값에 맡기면 서비스가 계속 호출자를 신뢰하게 됩니다. 대상 테이블 `LETTNBBS`의 PK가 `(NTT_ID, BBS_ID)`이고 이 조회는 PK 단건 조회라, 삭제 시점에 한 번 더 도는 비용은 크지 않습니다.

요청 DTO의 `atchFileId` 필드는 API 호환을 위해 그대로 뒀습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovBBSManageServiceImplTest`에 2건을 추가했습니다.

수정 전(RED)

```
[ERROR] Tests run: 5, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovBBSManageServiceImplTest.testDeleteBoardArticle_UsesStoredAtchFileId
          expected: <FILE_STORED> but was: <FILE_FROM_CLIENT>
[ERROR]   EgovBBSManageServiceImplTest.testDeleteBoardArticle_CleansUpWhenRequestOmitsAtchFileId
```

수정 후(GREEN, CI와 동일한 `mvn -B package -DexcludedGroups=browser`)

```
[INFO] Tests run: 140, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

백엔드 서비스 로직 변경이라 화면과 무관하여 JUnit 단위 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
