### PR TITLE
fix: Fix hardcoded NTT_NO value in replyBoardArticle query

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -113,7 +113,7 @@
 			( #{nttId}, #{bbsId}, #{nttSj}, #nttCn:CLOB#, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
-			  #{parnts}, 1, #{replyLc}, #{atchFileId},
+			  #{parnts}, #{nttNo}, #{replyLc}, #{atchFileId},
 			  #{frstRegisterId}, SYSDATE, 'Y'
 			 )			
 		

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
@@ -113,7 +113,7 @@
 			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
-			  #{parnts}, 1, #{replyLc}, #{atchFileId},
+			  #{parnts}, #{nttNo}, #{replyLc}, #{atchFileId},
 			  #{frstRegisterId}, SYSDATETIME, 'Y'
 			 )			
 		

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
@@ -113,7 +113,7 @@
 			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
-			  #{parnts}, 1, #{replyLc}, #{atchFileId},
+			  #{parnts}, #{nttNo}, #{replyLc}, #{atchFileId},
 			  #{frstRegisterId}, NOW(), 'Y'
 			 )			
 		

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
@@ -113,7 +113,7 @@
 			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
-			  #{parnts}, 1, #{replyLc}, #{atchFileId},
+			  #{parnts}, #{nttNo}, #{replyLc}, #{atchFileId},
 			  #{frstRegisterId}, SYSDATE(), 'Y'
 			 )			
 		

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
@@ -113,7 +113,7 @@
 			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
-			  #{parnts}, 1, #{replyLc}, #{atchFileId},
+			  #{parnts}, #{nttNo}, #{replyLc}, #{atchFileId},
 			  #{frstRegisterId}, SYSDATE, 'Y'
 			 )			
 		

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
@@ -113,7 +113,7 @@
 			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
-			  #{parnts}, 1, #{replyLc}, #{atchFileId},
+			  #{parnts}, #{nttNo}, #{replyLc}, #{atchFileId},
 			  #{frstRegisterId}, SYSDATE, 'Y'
 			 )			
 		

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceReplyBoardArticleNttNoTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceReplyBoardArticleNttNoTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,13 +20,31 @@ import egovframework.let.cop.bbs.domain.repository.BBSAttributeManageDAO;
 import egovframework.let.cop.bbs.domain.repository.BBSManageDAO;
 
 /**
- * NttNO 테스트
+ * 
+ * description    : 답글 등록(replyBoardArticle) 쿼리의 NTT_NO 하드코딩 결함 검증 테스트
+ * 
+ * packageName    : egovframework.let.cop.bbs.service.impl
+ * fileName       : EgovBBSManageServiceReplyBoardArticleNttNoTest
+ * author         : kimminsol
+ * date           : 2026.08.26
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ————————————————————————————————————————————————————————————
+ * 2026.08.26       kimminsol          최초 생성
+ */
+
+/**
+ * 답글 등록 시 게시글 번호(NTT_NO) 바인딩 결함 검증
  *
- * selectKey(order="BEFORE")로 계산한 nttNo가 VALUES절에서 쓰이지 않고 리터럴 1로
- * 하드코딩되어 있던 버그를 검증한다. BBSManageDAO#replyBoardArticle(Board) 는
- * INSERT 직후 getParentNttNo/updateOtherNttNo/updateNttNo로 NTT_NO를 다시 덮어써서
- * 최종 결과만 보면 버그 유무와 무관하게 같아지므로, 이 보정 로직을 거치지 않고
- * INSERT문만 직접 실행해 실제로 저장된 값을 확인한다.
+ * selectKey(order="BEFORE")를 통해 산출된 nttNo가 VALUES 절에 바인딩되지 않고
+ * 리터럴 '1'로 하드코딩되어 있던 결함을 검증한다.
+ * 
+ * 서비스 로직(BBSManageDAO#replyBoardArticle)에서는 INSERT 직후 부모글 기준
+ * NTT_NO 재설정 및 UPDATE 작업(getParentNttNo/updateOtherNttNo/updateNttNo)을 수행하므로,
+ * 전체 프로세스 수행 후에는 결함 유무와 관계없이 최종 데이터가 동일해집니다.
+ * 따라서 후속 보정 로직을 거치지 않고 INSERT 단독 실행 시 DB에 실제로 저장되는
+ * NTT_NO 값을 직접 조회하여 결함 여부를 검증합니다.
+ * 
  */
 @SpringBootTest
 class EgovBBSManageServiceReplyBoardArticleNttNoTest {
@@ -84,12 +101,19 @@ class EgovBBSManageServiceReplyBoardArticleNttNoTest {
         Long firstReplyNttNo = fetchNttNo(bbsId, firstReply.getNttId());
         Long secondReplyNttNo = fetchNttNo(bbsId, secondReply.getNttId());
 
+        System.out.println("======================================");
+        System.out.println("bbsId               = " + bbsId);
+        System.out.println("parent  nttId/nttNo = " + parent.getNttId() + " / " + parent.getNttNo());
+        System.out.println("reply1  nttId/nttNo = " + firstReply.getNttId() + " / " + firstReplyNttNo);
+        System.out.println("reply2  nttId/nttNo = " + secondReply.getNttId() + " / " + secondReplyNttNo);
+        System.out.println("======================================");
+
         assertNotEquals(1L, firstReplyNttNo, "selectKey로 계산한 값 대신 하드코딩된 1이 저장되면 안 된다.");
         assertEquals(2L, firstReplyNttNo);
         assertEquals(3L, secondReplyNttNo);
     }
 
-    private Board newReply(String bbsId, Board parent) throws FdlException {
+    private Board newReply(String bbsId, Board parent) throws Exception {
         Board reply = new Board();
         reply.setBbsId(bbsId);
         reply.setNttId(egovNttIdGnrService.getNextLongId());

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceReplyBoardArticleNttNoTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceReplyBoardArticleNttNoTest.java
@@ -1,0 +1,111 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import egovframework.let.cop.bbs.domain.model.Board;
+import egovframework.let.cop.bbs.domain.model.BoardMaster;
+import egovframework.let.cop.bbs.domain.repository.BBSAttributeManageDAO;
+import egovframework.let.cop.bbs.domain.repository.BBSManageDAO;
+
+/**
+ * NttNO 테스트
+ *
+ * selectKey(order="BEFORE")로 계산한 nttNo가 VALUES절에서 쓰이지 않고 리터럴 1로
+ * 하드코딩되어 있던 버그를 검증한다. BBSManageDAO#replyBoardArticle(Board) 는
+ * INSERT 직후 getParentNttNo/updateOtherNttNo/updateNttNo로 NTT_NO를 다시 덮어써서
+ * 최종 결과만 보면 버그 유무와 무관하게 같아지므로, 이 보정 로직을 거치지 않고
+ * INSERT문만 직접 실행해 실제로 저장된 값을 확인한다.
+ */
+@SpringBootTest
+class EgovBBSManageServiceReplyBoardArticleNttNoTest {
+
+    @Autowired
+    private BBSAttributeManageDAO bbsAttributeManageDAO;
+
+    @Autowired
+    private BBSManageDAO bbsMngDAO;
+
+    @Autowired
+    @Qualifier("egovBBSMstrIdGnrService")
+    private EgovIdGnrService egovBBSMstrIdGnrService;
+
+    @Autowired
+    @Qualifier("egovNttIdGnrService")
+    private EgovIdGnrService egovNttIdGnrService;
+
+    @Autowired
+    private SqlSessionTemplate sqlSessionTemplate;
+
+    @Test
+    @DisplayName("replyBoardArticle INSERT문은 selectKey로 계산한 nttNo를 그대로 저장한다 (하드코딩된 1이 아님)")
+    void insertedNttNo_followsSelectKeyValue_notHardcodedOne() throws Exception {
+        // given: 새 게시판과 원글(부모글) 하나 준비
+        String bbsId = egovBBSMstrIdGnrService.getNextStringId();
+
+        BoardMaster boardMaster = new BoardMaster();
+        boardMaster.setBbsId(bbsId);
+        String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS"));
+        boardMaster.setBbsNm("test nttNo 게시판 " + now);
+        boardMaster.setPosblAtchFileSize("0");
+        bbsAttributeManageDAO.insertBBSMasterInf(boardMaster);
+
+        Board parent = new Board();
+        parent.setBbsId(bbsId);
+        parent.setNttId(egovNttIdGnrService.getNextLongId());
+        parent.setNttSj("부모글");
+        parent.setNttCn("부모글 내용");
+        parent.setParnts("0");
+        parent.setReplyLc("0");
+        parent.setReplyAt("N");
+        bbsMngDAO.insertBoardArticle(parent); // NTT_NO=1, SORT_ORDR=1로 등록됨
+
+        // when: replyBoardArticle의 INSERT문만 직접 실행 (뒤따르는 보정 UPDATE 전 상태를 확인하기 위함)
+        Board firstReply = newReply(bbsId, parent);
+        sqlSessionTemplate.insert("BBSManageDAO.replyBoardArticle", firstReply);
+
+        Board secondReply = newReply(bbsId, parent);
+        sqlSessionTemplate.insert("BBSManageDAO.replyBoardArticle", secondReply);
+
+        // then: 같은 스레드(BBS_ID+SORT_ORDR) 안에서 MAX(NTT_NO)+1이 순차적으로 계산되어
+        // 부모글(1) 다음으로 2, 3이 저장되어야 한다. 수정 전에는 두 답글 모두 1이 저장되었다.
+        Long firstReplyNttNo = fetchNttNo(bbsId, firstReply.getNttId());
+        Long secondReplyNttNo = fetchNttNo(bbsId, secondReply.getNttId());
+
+        assertNotEquals(1L, firstReplyNttNo, "selectKey로 계산한 값 대신 하드코딩된 1이 저장되면 안 된다.");
+        assertEquals(2L, firstReplyNttNo);
+        assertEquals(3L, secondReplyNttNo);
+    }
+
+    private Board newReply(String bbsId, Board parent) throws FdlException {
+        Board reply = new Board();
+        reply.setBbsId(bbsId);
+        reply.setNttId(egovNttIdGnrService.getNextLongId());
+        reply.setNttSj("답글");
+        reply.setNttCn("답글 내용");
+        reply.setParnts(String.valueOf(parent.getNttId()));
+        reply.setReplyLc("1");
+        reply.setReplyAt("Y");
+        reply.setSortOrdr(parent.getNttNo());
+        return reply;
+    }
+
+    private Long fetchNttNo(String bbsId, long nttId) {
+        Board lookup = new Board();
+        lookup.setBbsId(bbsId);
+        lookup.setParnts(String.valueOf(nttId));
+        return sqlSessionTemplate.selectOne("BBSManageDAO.getParentNttNo", lookup);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

답글 등록 쿼리(`replyBoardArticle`) 실행 시 `selectKey`로 계산한 게시글 번호(`NTT_NO`) 대신 하드코딩된 값 `1`이 INSERT되던 결함을 수정했습니다.

**[ 대상 파일 ]**

- `EgovBoard_SQL_altibase.xml`
- `EgovBoard_SQL_cubrid.xml`
- `EgovBoard_SQL_hsql.xml`
- `EgovBoard_SQL_mysql.xml`
- `EgovBoard_SQL_oracle.xml`
- `EgovBoard_SQL_tibero.xml` (총 6개 DB 방언 파일)

**[ 상세 내용 ]**

- `replyBoardArticle` 쿼리 내부에서 `selectKey`를 통해 다음 `NTT_NO`를 계산해 바인딩하고 있으나, 정작 `VALUES` 절에서는 리터럴 `1`을 직접 구동하고 있던 문제를 확인했습니다.
- 현재 비즈니스 로직(`EgovBBSManageServiceImpl.insertBoardArticle`)에서는 INSERT 직후 `BBSManageDAO`를 통해 부모글 기준 `NTT_NO` 재설정 및 UPDATE 작업을 수행하며, 전체 과정이 AOP 트랜잭션으로 묶여 있어 최종 DB 결과물에는 영향이 없었습니다.
- 하지만 계산된 `selectKey` 값을 무시하고 상수를 직접 구동하는 것은 명백한 구문 오류입니다. 향후 트랜잭션 분리나 DAO 재활용 등 로직 리팩토링 시 데이터 오염을 유발할 수 있어 선제적으로 수정했습니다.

### 테스트 방법 Test Procedure

**[ 검증 내용 ]**

- 일반적인 서비스 호출 흐름(게시글 등록 후 연속 답글 등록)은 후속 UPDATE 보정 로직 때문에 수정 전후 결과가 동일하여 구분이 불가능합니다.
- 이에 따라 `SqlSessionTemplate`을 사용해 `BBSManageDAO.replyBoardArticle` INSERT 쿼리만 단독 실행한 뒤, 후속 UPDATE가 적용되기 전의 순수 저장 값을 검증했습니다.
    - **수정 전:** INSERT 직후 `NTT_NO`에 하드코딩된 `1` 저장
    - **수정 후:** `selectKey`에서 계산된 정상 연번(예: 2, 3...) 저장
- 해당 검증 내용을 바탕으로 회귀 테스트 단위 테스트(`EgovBBSManageServiceReplyBoardArticleNttNoTest`)를 추가했습니다.
    - 위치: `src/test/java/egovframework/let/cop/bbs/service/impl/`

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

백엔드 서비스 로직 변경이라 화면과 무관하여 JUnit 단위 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

<img width="635" height="182" alt="image" src="https://github.com/user-attachments/assets/82167bd9-b11a-4429-9432-af4bb1b4499e" />
