### PR TITLE
fix: Fix NullPointerException when calling /schedule/week without query params

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
@@ -55,6 +55,7 @@ import lombok.RequiredArgsConstructor;
  *  -------    --------    ---------------------------
  *  2009.04.10  장동한          최초 생성
  *  2011.05.31  JJY           경량환경 커스터마이징버전 생성
+ *  2026.08.27  content_j     /schedule/wee (EgovIndvdlSchdulManageWeekList) 파라미터 없이 호출 시 NPE 발생하던 버그 수정
  * </pre>
  * @author 조재영
  * @version 1.0
@@ -496,29 +497,35 @@ public class EgovIndvdlSchdulManageApiController {
 		String strYear = searchVO.getYear();
 		String strMonth = searchVO.getMonth();
 		String strDate = searchVO.getDate();
-		
+
+		int iNowYear = calNow.get(Calendar.YEAR);
 		int iNowMonth = calNow.get(Calendar.MONTH);
+		int iNowDate = calNow.get(Calendar.DATE);
 
 		if (strYear != null) {
+			iNowYear = Integer.parseInt(strYear);
 			iNowMonth = Integer.parseInt(strMonth);
+			iNowDate = Integer.parseInt(strDate);
 		}
-		
+
 		//프론트에서 넘어온 값은 1월을 0으로 간주하므로 1달 더해 줌
 		int realMonth = iNowMonth + 1;
-		strMonth =  String.valueOf(realMonth);
+		strYear = String.valueOf(iNowYear);
+		strMonth = String.valueOf(realMonth);
+		strDate = String.valueOf(iNowDate);
 
 		//자릿수 보정
 		strMonth = (strMonth.length() == 1) ? "0" + strMonth : strMonth;
 		strDate = (strDate.length() == 1) ? "0" + strDate : strDate;
-		
+
 		//시작일자
 		String schdulBgnde = strYear + strMonth + strDate;
 
 		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
 		Calendar calNext = Calendar.getInstance();
-		
-		calNext.set(Integer.parseInt(strYear), Integer.parseInt(strMonth)-1, Integer.parseInt(strDate));
-		
+
+		calNext.set(iNowYear, iNowMonth, iNowDate);
+
 		calNext.add(Calendar.DATE, 6);
 		
 		//종료일자

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerWeekListTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerWeekListTest.java
@@ -1,0 +1,110 @@
+package egovframework.let.cop.smt.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovFileMngUtil;
+import egovframework.com.cmm.service.ResultVO;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.cop.smt.sim.service.EgovIndvdlSchdulManageService;
+import egovframework.let.cop.smt.sim.service.ScheduleSearchVO;
+
+/**
+ * @Class             EgovIndvdlSchdulManageApiControllerWeekListTest.java
+ * @Description     year/month/date 파라미터 없이 "이번 주" 조회 시 strDate가 null인 채로 쓰여
+ *                        NullPointerException이 발생하던 EgovIndvdlSchdulManageWeekList()의
+ *                        버그 회귀 테스트
+ * @author            content_j
+ * @since             2026. 8. 27.
+ *
+ * <pre>
+ * <개정이력(Modification Information)>
+ * 개정일자                 개정자                  개정내용
+ * ------------------ ----------- --------------------------
+ * 2026. 8. 27.          content_j         최초생성
+ *
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovIndvdlSchdulManageApiControllerWeekListTest {
+
+	@Mock
+	private EgovIndvdlSchdulManageService egovIndvdlSchdulManageService;
+
+	@Mock
+	private EgovCmmUseService cmmUseService;
+
+	@Mock
+	private EgovFileMngService fileMngService;
+
+	@Mock
+	private EgovFileMngUtil fileUtil;
+
+	@Mock
+	private EgovCryptoService cryptoService;
+
+	private EgovIndvdlSchdulManageApiController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovIndvdlSchdulManageApiController(
+				egovIndvdlSchdulManageService, cmmUseService, fileMngService, fileUtil, cryptoService, new ResultVoHelper());
+	}
+
+	@Test
+	@DisplayName("year/month/date 파라미터 없이 호출해도 NPE 없이 오늘 날짜 기준 이번 주 범위(오늘~+6일)로 조회한다")
+	void weekList_withoutParams_doesNotThrowAndUsesTodayAsBaseDate() throws Exception {
+		// given: year/month/date 모두 null인 상태 (쿼리 파라미터 없이 호출한 상황)
+		when(cmmUseService.selectCmmCodeDetail(any())).thenReturn(Collections.emptyList());
+		when(egovIndvdlSchdulManageService.selectIndvdlSchdulManageRetrieve(any())).thenReturn(Collections.emptyList());
+
+		ScheduleSearchVO searchVO = new ScheduleSearchVO();
+
+		// when & then: 수정 전에는 strDate.length()에서 NullPointerException 발생
+		ResultVO result = assertDoesNotThrow(() -> controller.EgovIndvdlSchdulManageWeekList(searchVO));
+		assertNotNull(result);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, Object>> paramCaptor = ArgumentCaptor.forClass(Map.class);
+		verify(egovIndvdlSchdulManageService).selectIndvdlSchdulManageRetrieve(paramCaptor.capture());
+
+		SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd");
+		String expectedBgnde = fmt.format(Calendar.getInstance().getTime());
+
+		Calendar expectedEndCal = Calendar.getInstance();
+		expectedEndCal.add(Calendar.DATE, 6);
+		String expectedEndde = fmt.format(expectedEndCal.getTime());
+
+		Map<String, Object> capturedParams = paramCaptor.getValue();
+
+		System.out.println("======================================");
+		System.out.println("searchMode  = " + capturedParams.get("searchMode"));
+		System.out.println("schdulBgnde = " + capturedParams.get("schdulBgnde") + " (expected " + expectedBgnde + ")");
+		System.out.println("schdulEndde = " + capturedParams.get("schdulEndde") + " (expected " + expectedEndde + ")");
+		System.out.println("======================================");
+
+		assertEquals("WEEK", capturedParams.get("searchMode"));
+		assertEquals(expectedBgnde, capturedParams.get("schdulBgnde"));
+		assertEquals(expectedEndde, capturedParams.get("schdulEndde"));
+	}
+}


### PR DESCRIPTION

## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

일정 주간 목록 조회(`GET /schedule/week`, `EgovIndvdlSchdulManageWeekList`)를 쿼리 파라미터 없이 호출하면 `NullPointerException`이 발생하던 결함을 수정했습니다.

**[ 대상 파일 ]**

- `EgovIndvdlSchdulManageApiController.java`

**[ 상세 내용 ]**

- `year`/`month`/`date` 쿼리 파라미터가 모두 선택값(optional)인데, `month`에만 오늘 날짜 기준 fallback 처리가 되어 있고 `year`/`date`는 fallback이 없었습니다.
- 파라미터 없이 호출("이번 주 일정 조회"라는 가장 자연스러운 사용 패턴)하면 `strDate`가 `null`인 채로 `strDate.length()`에 그대로 쓰여 `NullPointerException`이 발생했습니다. (뒤이어 `Integer.parseInt(strYear)`에서도 `strYear`가 `null`이면 `NumberFormatException` 발생)
- 같은 파일의 `EgovIndvdlSchdulManageDailyList()` 메소드는 연/월/일 전부 `Calendar.getInstance()` 기준으로 fallback 처리한 뒤 파라미터가 있을 때만 셋 다 함께 덮어쓰는 일관된 패턴을 쓰고 있어, 이 패턴을 그대로 적용해 연/월/일 전부 오늘 날짜로 fallback 처리하도록 통일했습니다.

## 테스트 방법 Test Procedure

**[ 검증 내용 ]**

- `GET /schedule/week`를 쿼리 파라미터 없이 호출했을 때 예외 없이 오늘 날짜 기준 이번 주(오늘~+6일) 범위로 정상 조회되는지 검증했습니다.
  - **수정 전:** `NullPointerException` 발생, 500 응답
  - **수정 후:** 오늘 날짜가 포함된 주(이번 주)의 일정 목록이 정상 반환됨
- 파라미터를 명시해서 호출하는 기존 경로는 수정 전후 동일하게 동작함을 함께 확인했습니다 (회귀 없음).
- 회귀 테스트(`EgovIndvdlSchdulManageApiControllerWeekListTest`)를 추가했습니다.
  - 위치: `src/test/java/egovframework/let/cop/smt/sim/web/`

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

백엔드 컨트롤러 로직 변경이라 화면과 무관하여 JUnit 단위 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
[수정 전]
<img width="1399" height="312" alt="EgovIndvdlSchdulManageWeekList-EXCEPTION" src="https://github.com/user-attachments/assets/1c515631-b5e7-40a9-85aa-0e1fed69ce36" />
[수정 후]
<img width="1397" height="282" alt="EgovIndvdlSchdulManageWeekList" src="https://github.com/user-attachments/assets/153b5483-3eb8-45b7-b1a5-4cadcf7761f5" />
