### PR TITLE
fix(bbs): 게시판 마스터 수정에 검증이 걸리지 않아 필수값 공백이 그대로 저장됨

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiController.java
@@ -252,7 +252,7 @@ public class EgovBBSAttributeManageApiController {
 				        )),
 				})
 	@PutMapping(value ="/bbsMaster/{bbsId}")
-	public IntermediateResultVO<Object> updateBBSMasterInf(@RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
+	public IntermediateResultVO<Object> updateBBSMasterInf(@Valid @RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
 										BindingResult bindingResult,
 										@Parameter(hidden = true) @AuthenticationPrincipal LoginVO loginVO
 										) throws Exception {

--- a/src/main/java/egovframework/let/cop/bbs/dto/request/BbsAttributeUpdateRequestDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/request/BbsAttributeUpdateRequestDTO.java
@@ -1,6 +1,7 @@
 package egovframework.let.cop.bbs.dto.request;
 
 import egovframework.let.cop.bbs.domain.model.BoardMaster;
+import jakarta.validation.constraints.NotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -32,18 +33,22 @@ public class BbsAttributeUpdateRequestDTO {
     private String bbsId;
 
     @Schema(description = "게시판 명", example = "공지사항")
+    @NotBlank
     private String bbsNm;
 
     @Schema(description = "게시판 소개", example = "소개글입니다.")
+    @NotBlank
     private String bbsIntrcn;
 
     @Schema(description = "게시판 유형 코드", example = "BBST03")
+    @NotBlank
     private String bbsTyCode;
 
     @Schema(description = "게시판 유형명", example = "공지게시판")
     private String bbsTyCodeNm;
 
     @Schema(description = "게시판 속성 코드", example = "BBSA03")
+    @NotBlank
     private String bbsAttrbCode;
 
     @Schema(description = "게시판 속성명", example = "일반게시판")


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시판 마스터 수정(`PUT /bbsMaster/{bbsId}`)에 검증이 걸리지 않습니다. `updateBBSMasterInf`는 `BindingResult`를 받아 `bindingResult.hasErrors()` 분기를 두고 있으나 `@Valid`가 없고 `BbsAttributeUpdateRequestDTO`에는 제약이 하나도 없습니다. 그래서 이 분기는 실행될 수 없습니다.

같은 컨트롤러의 등록(`insertBBSMasterInf`)은 보호가 있습니다.

```java
// 등록 — 검증 있음
public IntermediateResultVO<...> insertBBSMasterInf(
    @Valid @ParameterObject BbsAttributeInsertRequestDTO ...)
// BbsAttributeInsertRequestDTO: bbsNm·bbsIntrcn·bbsTyCode·bbsAttrbCode 에 @NotBlank

// 수정 — 검증 없음
public IntermediateResultVO<...> updateBBSMasterInf(
    @RequestBody BbsAttributeUpdateRequestDTO ...)   // @Valid 없음, DTO 제약 0개
```

등록은 게시판명을 필수로 강제하는데 수정에는 같은 보호가 없어 게시판명을 빈 문자열로 보내면 그대로 저장됩니다.

등록 DTO와 같은 네 필드(`bbsNm`·`bbsIntrcn`·`bbsTyCode`·`bbsAttrbCode`)에 `@NotBlank`를 넣고 수정 핸들러에 `@Valid`를 붙였습니다. 이미 있던 `hasErrors()` 분기가 그대로 응답을 만듭니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

앱을 띄우고(HSQL 내장) 관리자로 로그인해 확인했습니다.

수정 전 — 게시판명을 빈 문자열로 `PUT`

```
HTTP 200  {"resultCode":200,"resultMessage":"성공했습니다."}
조회 결과  bbsNm: "공지사항" → ""      (이름이 지워짐)
```

수정 후 — 같은 요청

```
HTTP 200  {"resultCode":900,"resultMessage":"입력값 무결성 오류 입니다."}
조회 결과  bbsNm: "공지사항"           (그대로 유지)
```

수정 후 — 정상 요청

```
bbsNm "공지사항" → "공지사항-수정" → "공지사항"   (정상 반영)
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

로컬에 띄운 인스턴스에 HTTP 요청을 보냈습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 응답과 조회 결과로 대신합니다.
