### PR TITLE
fix(mapper): 알티베이스 매퍼가 지정한 iBATIS 타입핸들러 제거

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -28,7 +28,7 @@
 		<result property="ntcrId" column="NTCR_ID"/>
 		<result property="ntcrNm" column="NTCR_NM"/>
 		<result property="nttNo" column="NTT_NO"/>
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
 		<result property="password" column="PASSWORD"/>
 		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
@@ -66,7 +66,7 @@
 		<result property="ntcrNm" column="NTCR_NM"/>
 		<result property="password" column="PASSWORD"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
 		<result property="useAt" column="USE_AT"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>

--- a/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
+++ b/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
@@ -1,0 +1,78 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+/**
+ * 매퍼는 DB 타입과 무관하게 SqlSessionFactory 생성 단계를 통과한다.
+ *
+ * MyBatis의 {@code typeHandler} 속성은 {@code org.apache.ibatis.type.TypeHandler}
+ * 구현만 받는다. iBATIS 2 계약을 따르는 핸들러를 지정하면 매퍼를 읽는 시점에
+ * 팩토리 생성이 실패해 해당 DB 타입으로는 기동하지 못한다.
+ *
+ * @author 최완택
+ * @since 2026-09-01
+ * @see egovframework.com.config.EgovConfigAppMapper
+ */
+@DisplayName("매퍼 타입핸들러")
+class EgovMapperTypeHandlerTest {
+
+	private static final Path MAPPER_DIR = Paths.get("src/main/resources/egovframework/mapper/let");
+
+	private static final Pattern DB_TYPE = Pattern.compile("_([a-z]+)\\.xml$");
+
+	@Test
+	@DisplayName("모든 DB 타입에서 SqlSessionFactory 가 만들어진다")
+	void everyDbTypeBuildsSqlSessionFactory() throws IOException {
+		Set<String> dbTypes = dbTypes();
+		assertFalse(dbTypes.isEmpty(), "매퍼에서 DB 타입을 찾지 못했다: " + MAPPER_DIR);
+
+		for (String dbType : dbTypes) {
+			assertDoesNotThrow(() -> buildSqlSessionFactory(dbType), "Globals.DbType=" + dbType);
+		}
+	}
+
+	private Set<String> dbTypes() throws IOException {
+		Set<String> dbTypes = new TreeSet<>();
+		try (Stream<Path> paths = Files.walk(MAPPER_DIR)) {
+			for (Path path : paths.filter(Files::isRegularFile).toList()) {
+				Matcher matcher = DB_TYPE.matcher(path.getFileName().toString());
+				if (matcher.find()) {
+					dbTypes.add(matcher.group(1));
+				}
+			}
+		}
+		return dbTypes;
+	}
+
+	/** {@link egovframework.com.config.EgovConfigAppMapper#sqlSession()} 과 같은 순서로 만든다. */
+	private void buildSqlSessionFactory(String dbType) throws Exception {
+		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+		SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
+		sqlSessionFactoryBean.setDataSource(new UnpooledDataSource());
+		sqlSessionFactoryBean.setConfigLocation(
+			resolver.getResource("classpath:/egovframework/mapper/config/mapper-config.xml"));
+		sqlSessionFactoryBean.setMapperLocations(
+			resolver.getResources("classpath:/egovframework/mapper/let/**/*_" + dbType + ".xml"));
+
+		sqlSessionFactoryBean.afterPropertiesSet();
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

알티베이스 매퍼가 `typeHandler`로 `AltibaseClobStringTypeHandler`를 지정합니다.

```xml
<!-- EgovBoard_SQL_altibase.xml:31, :69 -->
<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
```

이 클래스는 iBATIS 2 계약을 따릅니다.

```
$ javap org.egovframe.rte.psl.orm.ibatis.support.AbstractLobTypeHandler
public abstract class org.egovframe.rte.psl.orm.ibatis.support.AbstractLobTypeHandler
    extends com.ibatis.sqlmap.engine.type.BaseTypeHandler
```

MyBatis의 `typeHandler` 속성은 `org.apache.ibatis.type.TypeHandler` 구현만 받습니다. 그래서 `EgovConfigAppMapper.sqlSession()`이 이 매퍼를 읽는 시점에 팩토리 생성이 실패하고, `Globals.DbType=altibase`로는 기동하지 못합니다.

```
FAIL Globals.DbType=altibase
  Failed to parse mapping resource: 'EgovBoard_SQL_altibase.xml'
  root java.lang.IllegalStateException: No LobHandler found for configuration
       - lobHandler property must be set on SqlMapClientFactoryBean
```

같은 컬럼을 오라클 변종은 `jdbcType="CLOB"`만 두고, 나머지 넷(mysql·cubrid·tibero·hsql)은 속성 없이 매핑합니다. 오라클 쪽에 맞췄습니다.

AS-IS / TO-BE

```diff
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
```

`typeHandler` 지정은 저장소 전체에서 이 두 줄뿐입니다. `AltibaseClobStringTypeHandler` 클래스는 참조가 없어지지만, 삭제는 범위가 달라 이번 변경에 넣지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovConfigAppMapper.sqlSession()`과 같은 순서로 DB 타입마다 `SqlSessionFactory`를 만들어 보는 테스트를 추가했습니다.

수정 전

```
$ mvn test -Dtest=EgovMapperTypeHandlerTest
[ERROR] EgovMapperTypeHandlerTest.everyDbTypeBuildsSqlSessionFactory:47
        Globals.DbType=altibase ==> Unexpected exception thrown:
        java.io.IOException: Failed to parse mapping resource: 'EgovBoard_SQL_altibase.xml'
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정 후

```
$ mvn test -Dtest=EgovMapperTypeHandlerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

여섯 변종 모두 매핑 구문 96개로 같습니다.

```
$ mvn test -DexcludedGroups=browser
[INFO] Tests run: 145, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`maven.yml`과 같은 조건으로 돌렸습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

알티베이스 환경이 없어 브라우저로 확인하지 못했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.
