### PR TITLE
fix(mapper): 일정 수정 SQL 이 일정장소 컬럼을 저장하지 않는 문제 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
@@ -241,6 +241,7 @@
 			SCHDUL_ENDDE=#{schdulEndde},
 			SCHDUL_NM=#{schdulNm},
 			SCHDUL_CN=#{schdulCn},
+			SCHDUL_PLACE=#{schdulPlace},
 			SCHDUL_IPCR_CODE=#{schdulIpcrCode},
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
@@ -242,6 +242,7 @@
 			SCHDUL_ENDDE=#{schdulEndde},
 			SCHDUL_NM=#{schdulNm},
 			SCHDUL_CN=#{schdulCn},
+			SCHDUL_PLACE=#{schdulPlace},
 			SCHDUL_IPCR_CODE=#{schdulIpcrCode},
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_hsql.xml
@@ -229,6 +229,7 @@
 			SCHDUL_ENDDE=TO_TIMESTAMP(SUBSTRING(#{schdulEndde}, 1, 4) || '-' || SUBSTRING(#{schdulEndde}, 5, 2) || '-' ||  SUBSTRING(#{schdulEndde}, 7, 2) || ' ' ||  SUBSTRING(#{schdulEndde}, 9, 2) || ':' || SUBSTRING(#{schdulEndde}, 11, 2), 'YYYY-MM-DD HH:MI'),
 			SCHDUL_NM=#{schdulNm},
 			SCHDUL_CN=#{schdulCn},
+			SCHDUL_PLACE=#{schdulPlace},
 			SCHDUL_IPCR_CODE=#{schdulIpcrCode},
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
@@ -228,6 +228,7 @@
 			SCHDUL_ENDDE=#{schdulEndde},
 			SCHDUL_NM=#{schdulNm},
 			SCHDUL_CN=#{schdulCn},
+			SCHDUL_PLACE=#{schdulPlace},
 			SCHDUL_IPCR_CODE=#{schdulIpcrCode},
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
@@ -242,6 +242,7 @@
 			SCHDUL_ENDDE=#{schdulEndde},
 			SCHDUL_NM=#{schdulNm},
 			SCHDUL_CN=#{schdulCn},
+			SCHDUL_PLACE=#{schdulPlace},
 			SCHDUL_IPCR_CODE=#{schdulIpcrCode},
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
@@ -242,6 +242,7 @@
 			SCHDUL_ENDDE=#{schdulEndde},
 			SCHDUL_NM=#{schdulNm},
 			SCHDUL_CN=#{schdulCn},
+			SCHDUL_PLACE=#{schdulPlace},
 			SCHDUL_IPCR_CODE=#{schdulIpcrCode},
 			SCHDUL_CHARGER_ID=#{schdulChargerId},
 			ATCH_FILE_ID=#{atchFileId},

--- a/src/test/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageDaoUpdateTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageDaoUpdateTest.java
@@ -1,0 +1,61 @@
+package egovframework.let.cop.smt.sim.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+/**
+ * [일정관리][IndvdlSchdulManageDao.updateIndvdlSchdulManage] DAO 단위 테스트
+ *
+ * 등록은 SCHDUL_PLACE 를 저장하고 상세조회는 그 값을 돌려준다.
+ * 수정도 같은 컬럼을 저장하는지 확인한다.
+ */
+@SpringBootTest
+@Transactional
+class IndvdlSchdulManageDaoUpdateTest {
+
+	@Autowired
+	private IndvdlSchdulManageDao indvdlSchdulManageDao;
+
+	private IndvdlSchdulManageVO newSchdul(String schdulId, String schdulPlace) {
+		IndvdlSchdulManageVO vo = new IndvdlSchdulManageVO();
+		vo.setSchdulId(schdulId);
+		vo.setSchdulSe("1");
+		vo.setSchdulDeptId("ORGNZT_0000000000000");
+		vo.setSchdulKindCode("01");
+		vo.setSchdulBgnde("202609010900");
+		vo.setSchdulEndde("202609011000");
+		vo.setSchdulNm("일정장소 저장 확인");
+		vo.setSchdulCn("내용");
+		vo.setSchdulPlace(schdulPlace);
+		vo.setSchdulIpcrCode("1");
+		vo.setSchdulChargerId("USRCNFRM_00000000000");
+		vo.setAtchFileId("");
+		vo.setReptitSeCode("0");
+		vo.setFrstRegisterId("USRCNFRM_00000000000");
+		vo.setLastUpdusrId("USRCNFRM_00000000000");
+		return vo;
+	}
+
+	@DisplayName("일정을 수정하면 일정장소도 함께 저장된다.")
+	@Test
+	void updateIndvdlSchdulManageSavesSchdulPlace() throws Exception {
+		// given
+		String schdulId = "SCHDUL_TEST000000001";
+		indvdlSchdulManageDao.insertIndvdlSchdulManage(newSchdul(schdulId, "등록한 장소"));
+
+		// when
+		indvdlSchdulManageDao.updateIndvdlSchdulManage(newSchdul(schdulId, "수정한 장소"));
+
+		// then
+		IndvdlSchdulManageVO saved = indvdlSchdulManageDao.selectIndvdlSchdulManageDetail(newSchdul(schdulId, null));
+		assertEquals("수정한 장소", saved.getSchdulPlace());
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

개인일정 수정 SQL 의 `SET` 절에 `SCHDUL_PLACE` 가 없습니다. 방언 여섯 벌이 모두 그렇습니다.

```
$ for d in altibase cubrid hsql mysql oracle tibero; do
>   printf '%-10s ' "$d"
>   git show origin/main:src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_$d.xml \
>     | awk '/<update id="updateIndvdlSchdulManage"/,/<\/update>/' | grep -c SCHDUL_PLACE
> done
altibase   0
cubrid     0
hsql       0
mysql      0
oracle     0
tibero     0
```

같은 매퍼의 조회 문장 다섯이 모두 이 컬럼을 읽고 등록 SQL 이 값을 저장합니다. 수정 문장만 빠졌습니다. `resultMap` 이 `schdulPlace` 에 매핑하고(`EgovIndvdlSchdulManage_SQL_mysql.xml:18`), 상세조회가 그 값을 돌려주며(`:131` `selectIndvdlSchdulManageDetailVO`), 등록이 저장합니다(`:268` `insertIndvdlSchdulManage`). `IndvdlSchdulManageVO:57` 에도 필드가 있습니다.

수정 경로에는 API 로 도달합니다. `EgovIndvdlSchdulManageApiController:327` 의 `PUT /schedule/{schdulId}` 가 `IndvdlSchdulManageVO` 를 바인딩하고 아이디·첨부파일 필드만 세팅한 뒤 같은 VO 를 `updateIndvdlSchdulManage` 에 넘깁니다(`:382`). `schdulPlace` 는 중간에서 손대지 않으므로 요청이 보낸 장소값은 VO 까지 실려 오고 SQL 에서 버려집니다.

`SET` 절에서 빠졌을 뿐이라 컬럼이 `NULL` 이 되지는 않습니다. 등록 시점 값이 그대로 남고 수정 요청이 보낸 장소값만 사라집니다.

AS-IS

```xml
SCHDUL_CN=#{schdulCn},
SCHDUL_IPCR_CODE=#{schdulIpcrCode},
```

TO-BE

```xml
SCHDUL_CN=#{schdulCn},
SCHDUL_PLACE=#{schdulPlace},
SCHDUL_IPCR_CODE=#{schdulIpcrCode},
```

### 영향 범위

여섯 방언에 같은 한 줄씩만 넣었고 등록 SQL 이 쓰는 자리와 같은 위치입니다. 다른 문장과 다른 컬럼은 그대로입니다.

열린 [#111](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/111) 이 같은 `mysql` 매퍼의 같은 `UPDATE` 문에서 `sysdate()` 를 `NOW()` 로 바꿉니다. 서로 다른 줄이라 시험 병합에서 그 파일은 자동 병합됐습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

등록 → 수정 → 상세조회로 왕복하는 DAO 테스트를 함께 넣었습니다. 기본 설정이 `Globals.DbType=hsql` 이라 hsql 매퍼를 탑니다.

수정 전에는 이렇게 실패합니다.

```
[ERROR] Failures:
[ERROR]   IndvdlSchdulManageDaoUpdateTest.updateIndvdlSchdulManageSavesSchdulPlace:58 expected: <수정한 장소> but was: <등록한 장소>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

값이 `NULL` 이 아니라 등록 시점 값으로 남는 것이 출력에 그대로 나옵니다.

수정 후에는 CI 와 같은 명령이 통과합니다.

```
$ mvn -B package -DexcludedGroups=browser
[INFO] Tests run: 146, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

매퍼 수정이라 브라우저 테스트는 하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 위 「JUnit 테스트」 절의 출력으로 대신합니다.
