### PR TITLE
docs(datasource): DB 설정 가이드를 현재 HikariCP 구현에 맞게 수정

### DIFF
--- a/Docs/context-datasource-convert.md
+++ b/Docs/context-datasource-convert.md
@@ -1,119 +1,19 @@
-# context-datasource.xml 설정 변환
+# 데이터소스 설정 (JavaConfig)
 
-기존 `context-datasource.xml`의 설정을 현재 [EgovConfigAppDatasource.java](../src/main/java/egovframework/com/config/EgovConfigAppDatasource.java)의 JavaConfig 구현과 비교합니다. XML 예제는 이전 설정 방식이며, 현재 프로젝트는 `application.properties`의 값을 읽어 DataSource를 구성합니다.
+데이터소스는 [EgovConfigAppDatasource.java](../src/main/java/egovframework/com/config/EgovConfigAppDatasource.java)에서 구성합니다. [application.properties](../src/main/resources/application.properties)의 `Globals.DbType`으로 사용할 DB를 선택합니다.
 
-## 현재 DataSource 선택 방식
-
-[application.properties](../src/main/resources/application.properties)의 `Globals.DbType` 값으로 사용할 DataSource를 선택합니다.
-
-| `Globals.DbType` | 현재 구성 방식 |
+| `Globals.DbType` | 구성 방식 |
 | --- | --- |
-| `hsql` (기본값) | `EmbeddedDatabaseBuilder`로 내장 HSQL DB 생성 |
-| `hsql` 이외의 값 | 해당 DB의 접속 설정을 읽어 `HikariDataSource` 구성 |
+| `hsql` (기본값) | 내장 HSQL DB |
+| `hsql` 이외의 값 | DB별 접속 설정을 사용하는 HikariCP |
 
-다음은 `EgovConfigAppDatasource.java`에서 DataSource Bean을 등록하는 부분입니다.
+## 내장 HSQL DB
 
-```java
-@Bean(name = {"dataSource", "egov.dataSource", "egovDataSource"})
-DataSource dataSource() {
-    if ("hsql".equals(dbType)) {
-        return dataSourceHSQL();
-    } else {
-        return hikariDataSource();
-    }
-}
-```
+`EmbeddedDatabaseBuilder`로 DB를 생성하고 `classpath:/db/shtdb.sql`로 초기화합니다. 이때 `Globals.hsql.Url` 등의 외부 접속 설정은 사용하지 않습니다.
 
-## 내장 HSQL DB 설정
+## 외부 DB (HikariCP)
 
-### 이전 XML 설정
-
-```xml
-<jdbc:embedded-database id="dataSource-hsql" type="HSQL">
-    <jdbc:script location= "classpath:/db/shtdb.sql"/>
-</jdbc:embedded-database>
-```
-
-### 현재 JavaConfig 구현
-
-```java
-private DataSource dataSourceHSQL() {
-    return new EmbeddedDatabaseBuilder()
-        .setType(EmbeddedDatabaseType.HSQL)
-        .setScriptEncoding("UTF8")
-        .addScript("classpath:/db/shtdb.sql")
-        //			.addScript("classpath:/otherpath/other.sql")
-        .build();
-}
-```
-
-기본값인 `Globals.DbType=hsql`에서는 `classpath:/db/shtdb.sql`을 읽어 내장 DB를 초기화합니다. 이 분기는 `Globals.hsql.Url` 등의 외부 접속 설정을 사용하지 않으므로, 해당 URL만 바꿔 외부 HSQL 서버에 연결되는 구조는 아닙니다.
-
-## 외부 DB 설정
-
-### 이전 XML 설정 (DBCP2)
-
-다음은 기존 `BasicDataSource` 기반 설정입니다. 여기의 `Globals.DriverClassName`, `Globals.Url` 등은 이전 XML 예제의 키이며, 현재 JavaConfig는 아래에 설명한 DB 종류별 키를 사용합니다.
-
-```xml
-<!-- mysql -->
-<bean id="dataSource-mysql" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-    <property name="driverClassName" value="${Globals.DriverClassName}"/>
-    <property name="url" value="${Globals.Url}" />
-    <property name="username" value="${Globals.UserName}"/>
-    <property name="password" value="${Globals.Password}"/>
-</bean>
-
-<!-- Oracle -->
-<bean id="dataSource-oracle" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-    <property name="driverClassName" value="${Globals.DriverClassName}"/>
-    <property name="url" value="${Globals.Url}" />
-    <property name="username" value="${Globals.UserName}"/>
-    <property name="password" value="${Globals.Password}"/>
-</bean>
-
-<!-- Altibase -->
-<bean id="dataSource-altibase" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-    <property name="driverClassName" value="${Globals.DriverClassName}"/>
-    <property name="url" value="${Globals.Url}" />
-    <property name="username" value="${Globals.UserName}"/>
-    <property name="password" value="${Globals.Password}"/>
-</bean>
-
-<!-- Tibero -->
-<bean id="dataSource-tibero" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-    <property name="driverClassName" value="${Globals.DriverClassName}"/>
-    <property name="url" value="${Globals.Url}" />
-    <property name="username" value="${Globals.UserName}"/>
-    <property name="password" value="${Globals.Password}"/>
-</bean>
-
-<!-- cubrid -->
-<bean id="dataSource-cubrid" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-    <property name="driverClassName" value="${Globals.DriverClassName}"/>
-    <property name="url" value="${Globals.Url}" />
-    <property name="username" value="${Globals.UserName}"/>
-    <property name="password" value="${Globals.Password}"/>
-</bean>
-```
-
-### 현재 JavaConfig 구현 (HikariCP)
-
-현재 프로젝트는 `pom.xml`에 선언된 HikariCP를 사용합니다. 아래 코드는 `EgovConfigAppDatasource.java`의 일부이며, 필드와 생성자는 원본 코드를 참고합니다.
-
-```java
-@PostConstruct
-void init() {
-    dbType = env.getProperty("Globals.DbType");
-    //Exception 처리 필요
-    className = env.getProperty("Globals." + dbType + ".DriverClassName");
-    url = env.getProperty("Globals." + dbType + ".Url");
-    userName = env.getProperty("Globals." + dbType + ".UserName");
-    password = env.getProperty("Globals." + dbType + ".Password");
-}
-```
-
-예를 들어 `Globals.DbType=mysql`이면 다음 설정을 읽습니다.
+`Globals.DbType`에 지정한 DB의 접속 정보를 읽어 `HikariDataSource`를 구성합니다. 예를 들어 `mysql`을 지정하면 다음 설정을 사용합니다.
 
 | 설정 키 | 용도 |
 | --- | --- |
@@ -122,11 +22,9 @@ void init() {
 | `Globals.mysql.UserName` | DB 사용자명 |
 | `Globals.mysql.Password` | DB 비밀번호 |
 
-읽어온 값은 다음과 같이 `HikariDataSource`에 전달합니다.
+다음은 접속 정보를 적용하는 메서드입니다. 최대 커넥션 풀 크기는 `10`으로 설정되어 있습니다.
 
 ```java
-import com.zaxxer.hikari.HikariDataSource;
-
 private DataSource hikariDataSource() {
     HikariDataSource hikariDataSource = new HikariDataSource();
     hikariDataSource.setDriverClassName(className);
@@ -137,5 +35,3 @@ private DataSource hikariDataSource() {
     return hikariDataSource;
 }
 ```
-
-기존 `BasicDataSource.setUrl()`에 해당하는 JDBC URL은 `HikariDataSource.setJdbcUrl()`로 설정합니다. 현재 코드의 최대 커넥션 풀 크기는 `setMaximumPoolSize(10)`으로 명시되어 있습니다.

--- a/Docs/context-datasource-convert.md
+++ b/Docs/context-datasource-convert.md
@@ -1,12 +1,32 @@
-# context-datasource.xml  설정 변환
+# context-datasource.xml 설정 변환
 
-> 데이터 소스관련 설정 사항들 다루고 있음
+기존 `context-datasource.xml`의 설정을 현재 [EgovConfigAppDatasource.java](../src/main/java/egovframework/com/config/EgovConfigAppDatasource.java)의 JavaConfig 구현과 비교합니다. XML 예제는 이전 설정 방식이며, 현재 프로젝트는 `application.properties`의 값을 읽어 DataSource를 구성합니다.
 
+## 현재 DataSource 선택 방식
 
+[application.properties](../src/main/resources/application.properties)의 `Globals.DbType` 값으로 사용할 DataSource를 선택합니다.
 
-내장 DB 사용시
+| `Globals.DbType` | 현재 구성 방식 |
+| --- | --- |
+| `hsql` (기본값) | `EmbeddedDatabaseBuilder`로 내장 HSQL DB 생성 |
+| `hsql` 이외의 값 | 해당 DB의 접속 설정을 읽어 `HikariDataSource` 구성 |
 
-<context-datasource.xml>
+다음은 `EgovConfigAppDatasource.java`에서 DataSource Bean을 등록하는 부분입니다.
+
+```java
+@Bean(name = {"dataSource", "egov.dataSource", "egovDataSource"})
+DataSource dataSource() {
+    if ("hsql".equals(dbType)) {
+        return dataSourceHSQL();
+    } else {
+        return hikariDataSource();
+    }
+}
+```
+
+## 내장 HSQL DB 설정
+
+### 이전 XML 설정
 
 ```xml
 <jdbc:embedded-database id="dataSource-hsql" type="HSQL">
@@ -14,7 +34,7 @@
 </jdbc:embedded-database>
 ```
 
-<EgovConfigAppDatasource.class>
+### 현재 JavaConfig 구현
 
 ```java
 private DataSource dataSourceHSQL() {
@@ -27,12 +47,13 @@ private DataSource dataSourceHSQL() {
 }
 ```
 
+기본값인 `Globals.DbType=hsql`에서는 `classpath:/db/shtdb.sql`을 읽어 내장 DB를 초기화합니다. 이 분기는 `Globals.hsql.Url` 등의 외부 접속 설정을 사용하지 않으므로, 해당 URL만 바꿔 외부 HSQL 서버에 연결되는 구조는 아닙니다.
 
+## 외부 DB 설정
 
+### 이전 XML 설정 (DBCP2)
 
-다른 DB 사용시
-
-<context-datasource.xml>
+다음은 기존 `BasicDataSource` 기반 설정입니다. 여기의 `Globals.DriverClassName`, `Globals.Url` 등은 이전 XML 예제의 키이며, 현재 JavaConfig는 아래에 설명한 DB 종류별 키를 사용합니다.
 
 ```xml
 <!-- mysql -->
@@ -76,10 +97,11 @@ private DataSource dataSourceHSQL() {
 </bean>
 ```
 
-<EgovConfigAppDatasource.class>
+### 현재 JavaConfig 구현 (HikariCP)
+
+현재 프로젝트는 `pom.xml`에 선언된 HikariCP를 사용합니다. 아래 코드는 `EgovConfigAppDatasource.java`의 일부이며, 필드와 생성자는 원본 코드를 참고합니다.
 
 ```java
-
 @PostConstruct
 void init() {
     dbType = env.getProperty("Globals.DbType");
@@ -89,15 +111,31 @@ void init() {
     userName = env.getProperty("Globals." + dbType + ".UserName");
     password = env.getProperty("Globals." + dbType + ".Password");
 }
+```
 
-......
+예를 들어 `Globals.DbType=mysql`이면 다음 설정을 읽습니다.
 
-private DataSource basicDataSource() {
-    BasicDataSource basicDataSource = new BasicDataSource();
-    basicDataSource.setDriverClassName(className);
-    basicDataSource.setUrl(url);
-    basicDataSource.setUsername(userName);
-    basicDataSource.setPassword(password);
-    return basicDataSource;
+| 설정 키 | 용도 |
+| --- | --- |
+| `Globals.mysql.DriverClassName` | JDBC 드라이버 클래스 |
+| `Globals.mysql.Url` | JDBC 접속 URL |
+| `Globals.mysql.UserName` | DB 사용자명 |
+| `Globals.mysql.Password` | DB 비밀번호 |
+
+읽어온 값은 다음과 같이 `HikariDataSource`에 전달합니다.
+
+```java
+import com.zaxxer.hikari.HikariDataSource;
+
+private DataSource hikariDataSource() {
+    HikariDataSource hikariDataSource = new HikariDataSource();
+    hikariDataSource.setDriverClassName(className);
+    hikariDataSource.setJdbcUrl(url);
+    hikariDataSource.setUsername(userName);
+    hikariDataSource.setPassword(password);
+    hikariDataSource.setMaximumPoolSize(10);
+    return hikariDataSource;
 }
 ```
+
+기존 `BasicDataSource.setUrl()`에 해당하는 JDBC URL은 `HikariDataSource.setJdbcUrl()`로 설정합니다. 현재 코드의 최대 커넥션 풀 크기는 `setMaximumPoolSize(10)`으로 명시되어 있습니다.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ java -jar <jar파일명> --spring.profiles.active=<profile명>
 | Aspect 설정                      | [Docs/context-aspect.md](Docs/context-aspect.md)                                       | @EnableAspectJAutoProxy로 프록시 기반 AOP 활성화 및 AOP 개념·옵션 요약                         |
 | context-aspect 설정 변환            | [Docs/context-aspect-convert.md](Docs/context-aspect-convert.md)                       | 예외 처리 AOP(context-aspect.xml) 를 JavaConfig로 변환하는 방법(Handler/패턴/매니저 등록)         |
 | context-common-convert 설정 변환   | [Docs/context-common-convert.md](Docs/context-common-convert.md)                       | 컴포넌트 스캔·메시지소스 등 공통 Bean을 context-common.xml에서 JavaConfig로 이전                   |
-| context-datasource.xml 설정 변환   | [Docs/context-datasource-convert.md](Docs/context-datasource-convert.md)               | HSQL 내장 DB·DBCP BasicDataSource 등 데이터소스 설정을 JavaConfig로 변환                     |
+| context-datasource.xml 설정 변환   | [Docs/context-datasource-convert.md](Docs/context-datasource-convert.md)               | 내장 HSQL·외부 DB HikariCP 설정과 XML→JavaConfig 변환                     |
 | [참고] Context Hierarchy(확인 필요)  | [Docs/context-hierarchy.md](Docs/context-hierarchy.md)                                 | Root/Servlet WebApplicationContext 계층 구조와 역할·로딩 방식 정리                          |
 | context-idgen.xml 설정 변환        | [Docs/context-idgen-convert.md](Docs/context-idgen-convert.md)                         | 테이블 기반 ID 생성기(EgovTableIdGnrServiceImpl) 전략·blockSize·관리 테이블 설정 변환             |
 | context-mapper.xml 설정 변환       | [Docs/context-mapper-convert.md](Docs/context-mapper-convert.md)                       | MyBatis SqlSessionFactory/매퍼·LobHandler 설정을 XML→JavaConfig로 이전                 |

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ java -jar <jar파일명> --spring.profiles.active=<profile명>
 | Aspect 설정                      | [Docs/context-aspect.md](Docs/context-aspect.md)                                       | @EnableAspectJAutoProxy로 프록시 기반 AOP 활성화 및 AOP 개념·옵션 요약                         |
 | context-aspect 설정 변환            | [Docs/context-aspect-convert.md](Docs/context-aspect-convert.md)                       | 예외 처리 AOP(context-aspect.xml) 를 JavaConfig로 변환하는 방법(Handler/패턴/매니저 등록)         |
 | context-common-convert 설정 변환   | [Docs/context-common-convert.md](Docs/context-common-convert.md)                       | 컴포넌트 스캔·메시지소스 등 공통 Bean을 context-common.xml에서 JavaConfig로 이전                   |
-| context-datasource.xml 설정 변환   | [Docs/context-datasource-convert.md](Docs/context-datasource-convert.md)               | 내장 HSQL·외부 DB HikariCP 설정과 XML→JavaConfig 변환                     |
+| 데이터소스 설정 (JavaConfig)       | [Docs/context-datasource-convert.md](Docs/context-datasource-convert.md)               | 내장 HSQL 및 외부 DB HikariCP 설정                                                    |
 | [참고] Context Hierarchy(확인 필요)  | [Docs/context-hierarchy.md](Docs/context-hierarchy.md)                                 | Root/Servlet WebApplicationContext 계층 구조와 역할·로딩 방식 정리                          |
 | context-idgen.xml 설정 변환        | [Docs/context-idgen-convert.md](Docs/context-idgen-convert.md)                         | 테이블 기반 ID 생성기(EgovTableIdGnrServiceImpl) 전략·blockSize·관리 테이블 설정 변환             |
 | context-mapper.xml 설정 변환       | [Docs/context-mapper-convert.md](Docs/context-mapper-convert.md)                       | MyBatis SqlSessionFactory/매퍼·LobHandler 설정을 XML→JavaConfig로 이전                 |


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

DB 설정 문서를 현재 JavaConfig 및 HikariCP 구현에 맞게 정리했습니다.

## 수정된 소스 내용 Modified source

- `Docs/context-datasource-convert.md`: 내장 HSQL과 외부 DB의 HikariCP 구성 방식, 접속 설정 키 및 현재 코드 예제를 설명하도록 수정했습니다.
- `README.md`: 관련 문서의 제목과 소개를 현재 내용에 맞게 수정했습니다.

애플리케이션 코드와 설정값 변경은 없습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

문서 변경으로 JUnit 및 애플리케이션 수동 테스트는 실행하지 않았습니다.
문서의 Java 예제와 설정 키를 실제 코드와 대조하고, 상대 링크의 대상 파일을 확인했습니다.
`git diff --check`를 통과했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 문서 변경으로 브라우저 테스트는 진행하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

문서 변경으로 별도 스크린샷이나 영상은 없습니다.