### PR TITLE
fix(config): DB 설정 사전 검증 및 오류 메시지 개선

### DIFF
--- a/src/main/java/egovframework/com/config/EgovConfigAppDatasource.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppDatasource.java
@@ -1,5 +1,8 @@
 package egovframework.com.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.annotation.PostConstruct;
 import javax.sql.DataSource;
 
@@ -9,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.util.StringUtils;
 
 /**
  * @ClassName : EgovConfigAppDatasource.java
@@ -49,12 +53,47 @@ public class EgovConfigAppDatasource {
 
 	@PostConstruct
 	void init() {
+
 		dbType = env.getProperty("Globals.DbType");
-		//Exception 처리 필요
-		className = env.getProperty("Globals." + dbType + ".DriverClassName");
-		url = env.getProperty("Globals." + dbType + ".Url");
-		userName = env.getProperty("Globals." + dbType + ".UserName");
-		password = env.getProperty("Globals." + dbType + ".Password");
+
+		// 우선 dbType이 null, 빈값, 공백인지 확인하고, dbType의 첫 글자는 영문 소문자, 이후는 소문자·숫자·밑줄·하이픈만 허용
+		// DB 종류가 Mapper 검색 패턴에 포함되므로 경로 구분자나 와일드카드가 들어가지 않도록 제한
+		// EgovConfigAppMapper.class의 Mapper 검색 패턴은 "**/mapper/**/*Mapper.xml"로 설정되어 있음
+		if (!StringUtils.hasText(dbType) || !dbType.matches("[a-z][a-z0-9_-]*")) {
+			String errMsg = "DB 설정 오류: Globals.DbType은 필수이며 소문자로 시작하는 [a-z][a-z0-9_-]* 형식이어야 합니다.";
+			throw new IllegalStateException(errMsg);
+		}
+
+		// 내장 HSQL은 초기화 SQL로 생성하므로 외부 접속용 JDBC 설정을 읽을 필요가 없음
+		if ("hsql".equals(dbType)) {
+			return;
+		}
+
+		String prefix = String.format("Globals.%s.", dbType);
+
+		className = env.getProperty(prefix + "DriverClassName");
+		url = env.getProperty(prefix + "Url");
+
+		// 한 번에 수정할 수 있도록 누락되거나 공백뿐인 필수 설정 키를 모두 수집
+		List<String> missingKeys = new ArrayList<>();
+		if (!StringUtils.hasText(className)) {
+			missingKeys.add(prefix + "DriverClassName");
+		}
+
+		if (!StringUtils.hasText(url)) {
+			missingKeys.add(prefix + "Url");
+		}
+
+		if (!missingKeys.isEmpty()) {
+			String message = String.format(
+					"DB 설정 오류: %s이 없거나 비어 있습니다. Globals.DbType과 해당 DB 설정을 확인하세요.",
+					String.join(", ", missingKeys));
+			throw new IllegalStateException(message);
+		}
+
+		// 인증과 관련된 username과 password는 공백 제거 없이 그대로 반환
+		userName = env.getProperty(prefix + "UserName");
+		password = env.getProperty(prefix + "Password");
 	}
 
 	/**
@@ -74,7 +113,18 @@ public class EgovConfigAppDatasource {
 	 */
 	private DataSource hikariDataSource() {
 		HikariDataSource hikariDataSource = new HikariDataSource();
-		hikariDataSource.setDriverClassName(className);
+
+		try {
+			hikariDataSource.setDriverClassName(className);
+		} catch (RuntimeException | LinkageError e) {
+			// 드라이버 로딩, 드라이버 클래스 누락, 버전 불일치 포함 등의 예외에 대해서만 예외처리
+			hikariDataSource.close();
+			String message = String.format(
+					"DB 설정 오류: Globals.%s.DriverClassName의 드라이버를 로딩하거나 생성할 수 없습니다. 클래스명과 JDBC 드라이버 의존성을 확인하세요.",
+					dbType);
+			throw new IllegalStateException(message, e);
+		}
+
 		hikariDataSource.setJdbcUrl(url);
 		hikariDataSource.setUsername(userName);
 		hikariDataSource.setPassword(password);

--- a/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
+++ b/src/main/java/egovframework/com/config/EgovConfigAppMapper.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 import org.springframework.core.env.Environment;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 
@@ -76,15 +77,32 @@ public class EgovConfigAppMapper {
 			pathMatchingResourcePatternResolver
 				.getResource("classpath:/egovframework/mapper/config/mapper-config.xml"));
 
+		// "classpath*:"는 추가 JAR 등 모든 클래스패스 위치를 파악하고, "**"는 하위 디렉터리 전체를 검색한다.
+		String mapperPattern = String.format("classpath*:/egovframework/mapper/let/**/*_%s.xml", dbType);
+
 		try {
-			sqlSessionFactoryBean.setMapperLocations(
-				pathMatchingResourcePatternResolver
-					.getResources("classpath:/egovframework/mapper/let/**/*_" + dbType + ".xml"));
+			Resource[] mapperLocations = pathMatchingResourcePatternResolver.getResources(mapperPattern);
+
+			// Globals.DbType에 해당하는 Mapper 검색 결과가 없을 경우의 예외처리
+			if (mapperLocations.length == 0) {
+				String message = String.format(
+						"DB 설정 오류: Globals.DbType=%s에 해당하는 Mapper 파일이 없습니다. 검색 경로: %s",
+						dbType, mapperPattern
+				);
+				throw new IllegalStateException(message);
+			}
+
+			sqlSessionFactoryBean.setMapperLocations(mapperLocations);
 		} catch (IOException e) {
 			// 26.03.04 KISA 보안취약점 조치
 			// 구체적인 Exception 명시
-			EgovBasicLogger.debug("Mapper 파일 로딩 중 오류가 발생했습니다.", e);
-			throw new IllegalStateException("Mapper 파일 로딩 중 오류가 발생했습니다.", e);
+			String errMsg = String.format(
+					"Mapper 파일 로딩 오류: Globals.DbType=%s, 검색 경로: %s",
+					dbType, mapperPattern
+			);
+
+			EgovBasicLogger.debug(errMsg, e);
+			throw new IllegalStateException(errMsg, e);
 		}
 
 		return sqlSessionFactoryBean;

--- a/src/test/java/egovframework/com/config/EgovConfigAppDatasourceTest.java
+++ b/src/test/java/egovframework/com/config/EgovConfigAppDatasourceTest.java
@@ -1,0 +1,151 @@
+package egovframework.com.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.env.MockEnvironment;
+
+
+class EgovConfigAppDatasourceTest {
+
+    @ParameterizedTest
+    @DisplayName("DB 종류가 누락되거나 허용 형식에 맞지 않으면 설정 오류가 발생한다")
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "MYSQL", " mysql", "mysql ", "my*sql", "../mysql", "1mysql"})
+    void rejectsMissingOrMalformedDbType(String dbType) {
+        MockEnvironment env = new MockEnvironment();
+        if (dbType != null) {
+            env.setProperty("Globals.DbType", dbType);
+        }
+        assertThatThrownBy(() -> new EgovConfigAppDatasource(env).init())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Globals.DbType");
+    }
+
+    @Test
+    @DisplayName("DB 종류에 오타가 있으면 드라이버와 URL의 누락된 설정 키를 함께 안내한다")
+    void reportsBothMissingKeysForUnknownDbType() {
+        MockEnvironment env = new MockEnvironment().withProperty("Globals.DbType", "mysqp");
+        assertThatThrownBy(() -> new EgovConfigAppDatasource(env).init())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Globals.mysqp.DriverClassName", "Globals.mysqp.Url", "Globals.DbType");
+    }
+
+    @ParameterizedTest
+    @DisplayName("드라이버 클래스명이 누락되거나 공백이면 해당 설정 키를 포함한 오류가 발생한다")
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void rejectsMissingOrBlankDriver(String driver) {
+        MockEnvironment env = externalEnvironment();
+        setOrRemove(env, "Globals.mysql.DriverClassName", driver);
+        assertThatThrownBy(() -> new EgovConfigAppDatasource(env).init())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Globals.mysql.DriverClassName")
+                .hasMessageNotContaining("Globals.mysql.Url");
+    }
+
+    @ParameterizedTest
+    @DisplayName("JDBC URL이 누락되거나 공백이면 해당 설정 키를 포함한 오류가 발생한다")
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void rejectsMissingOrBlankUrl(String url) {
+        MockEnvironment env = externalEnvironment();
+        setOrRemove(env, "Globals.mysql.Url", url);
+        assertThatThrownBy(() -> new EgovConfigAppDatasource(env).init())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Globals.mysql.Url")
+                .hasMessageNotContaining("Globals.mysql.DriverClassName");
+    }
+
+    @Test
+    @DisplayName("드라이버 로딩 실패 시 원인 예외를 보존하고 접속 정보 없이 설정 키와 확인 방법을 안내한다")
+    void identifiesDriverLoadingFailureAndPreservesCause() {
+        MockEnvironment env = externalEnvironment()
+                .withProperty("Globals.mysql.DriverClassName", "missing.jdbc.Driver")
+                .withProperty("Globals.mysql.Url", "jdbc:example:private-host")
+                .withProperty("Globals.mysql.UserName", "private-user")
+                .withProperty("Globals.mysql.Password", "private-password");
+        EgovConfigAppDatasource configuration = new EgovConfigAppDatasource(env);
+        configuration.init();
+        assertThatThrownBy(configuration::dataSource)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Globals.mysql.DriverClassName", "JDBC 드라이버 의존성")
+                .hasMessageNotContaining("private-host")
+                .hasMessageNotContaining("private-user")
+                .hasMessageNotContaining("private-password")
+                .hasCauseInstanceOf(RuntimeException.class);
+    }
+
+    @ParameterizedTest
+    @DisplayName("선택적 인증값을 그대로 전달하고 최대 풀 크기를 유지하며 연결 풀을 시작하지 않는다")
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", " value with spaces "})
+    void preservesOptionalCredentialsWithoutStartingPool(String credential) {
+        MockEnvironment env = externalEnvironment();
+        setOrRemove(env, "Globals.mysql.UserName", credential);
+        setOrRemove(env, "Globals.mysql.Password", credential);
+        EgovConfigAppDatasource configuration = new EgovConfigAppDatasource(env);
+        configuration.init();
+        try (HikariDataSource dataSource = (HikariDataSource) configuration.dataSource()) {
+            assertThat(dataSource.getUsername()).isEqualTo(credential);
+            assertThat(dataSource.getPassword()).isEqualTo(credential);
+            assertThat(dataSource.getMaximumPoolSize()).isEqualTo(10);
+            assertThat(dataSource.getHikariPoolMXBean()).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("내장 HSQL은 JDBC 설정을 읽지 않고 초기화 SQL을 실행하며 기존 빈 별칭을 유지한다")
+    void initializesEmbeddedSchemaWithoutReadingJdbcSettingsAndPreservesAliases() {
+        // 해석할 수 없는 플레이스홀더를 넣어 HSQL 경로에서 JDBC 설정을 읽지 않는지 확인한다.
+        new ApplicationContextRunner().withUserConfiguration(EgovConfigAppDatasource.class)
+                .withPropertyValues("Globals.DbType=hsql", "Globals.hsql.DriverClassName=${missing.driver}",
+                        "Globals.hsql.Url=${missing.url}", "Globals.hsql.UserName=${missing.user}",
+                        "Globals.hsql.Password=${missing.password}")
+                .run(context -> {
+                    assertThat(context).hasNotFailed().hasSingleBean(DataSource.class);
+                    DataSource dataSource = context.getBean(DataSource.class);
+                    assertThat(context.getBean("egov.dataSource")).isSameAs(dataSource);
+                    assertThat(context.getBean("egovDataSource")).isSameAs(dataSource);
+                    assertThat(new JdbcTemplate(dataSource).queryForObject("SELECT COUNT(*) FROM IDS", Integer.class))
+                            .isPositive();
+                });
+    }
+
+    @Test
+    @DisplayName("필수 JDBC 설정이 없으면 DataSource 생성 전 Spring 초기화가 실패한다")
+    void failsDuringSpringInitializationBeforeCreatingDataSource() {
+        new ApplicationContextRunner().withUserConfiguration(EgovConfigAppDatasource.class)
+                .withPropertyValues("Globals.DbType=mysqp")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasRootCauseInstanceOf(IllegalStateException.class)
+                            .rootCause().hasMessageContaining("Globals.mysqp.DriverClassName", "Globals.mysqp.Url");
+                });
+    }
+
+    private MockEnvironment externalEnvironment() {
+        return new MockEnvironment().withProperty("Globals.DbType", "mysql")
+                .withProperty("Globals.mysql.DriverClassName", "org.hsqldb.jdbc.JDBCDriver")
+                .withProperty("Globals.mysql.Url", "jdbc:hsqldb:mem:datasource-config-test");
+    }
+
+    private void setOrRemove(MockEnvironment env, String key, String value) {
+        if (value == null) {
+            ((MapPropertySource) env.getPropertySources().get("mockProperties")).getSource().remove(key);
+        } else {
+            env.setProperty(key, value);
+        }
+    }
+}

--- a/src/test/java/egovframework/com/config/EgovConfigAppMapperTest.java
+++ b/src/test/java/egovframework/com/config/EgovConfigAppMapperTest.java
@@ -1,0 +1,80 @@
+package egovframework.com.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.mock.env.MockEnvironment;
+
+class EgovConfigAppMapperTest {
+
+	@ParameterizedTest
+	@DisplayName("기본 제공하는 6종 DB의 Mapper를 로딩하고 로그인 쿼리를 등록한다")
+	@ValueSource(strings = {"hsql", "mysql", "oracle", "altibase", "tibero", "cubrid"})
+	void loadsStatementsForEachBundledDb(String dbType) throws Exception {
+		EgovConfigAppMapper configuration = new EgovConfigAppMapper(new UnpooledDataSource(),
+				new MockEnvironment().withProperty("Globals.DbType", dbType));
+		configuration.init();
+		SqlSessionFactoryBean factory = configuration.sqlSession();
+		factory.afterPropertiesSet();
+		assertThat(factory.getObject().getConfiguration().hasStatement("loginDAO.actionLogin")).isTrue();
+	}
+
+	@Test
+	@DisplayName("JDBC 설정이 있어도 해당 DB의 Mapper가 없으면 Spring 초기화가 실패한다")
+	void failsSpringStartupWhenJdbcSettingsExistButMappersAreMissing() {
+		new ApplicationContextRunner()
+				.withUserConfiguration(EgovConfigAppDatasource.class, EgovConfigAppMapper.class)
+				.withPropertyValues("Globals.DbType=missingdb",
+						"Globals.missingdb.DriverClassName=org.hsqldb.jdbc.JDBCDriver",
+						"Globals.missingdb.Url=jdbc:hsqldb:mem:missing-mapper-test")
+				.run(context -> {
+					assertThat(context).hasFailed();
+					assertThat(context.getStartupFailure()).hasRootCauseInstanceOf(IllegalStateException.class)
+							.rootCause().hasMessageContaining("Globals.DbType=missingdb", "Mapper 파일이 없습니다",
+									"classpath*:/egovframework/mapper/let/**/*_missingdb.xml");
+				});
+	}
+
+	@Test
+	@DisplayName("새 DB 설정과 추가 클래스패스의 Mapper로 실제 조회를 수행할 수 있다")
+	void supportsNewDbWithSettingsAndMappersOnAdditionalClasspath() throws Exception {
+		ClassLoader original = Thread.currentThread().getContextClassLoader();
+		URL extensionRoot = getClass().getResource("/db-extension/");
+		assertThat(extensionRoot).isNotNull();
+		try (URLClassLoader extensionLoader = new URLClassLoader(new URL[] {extensionRoot}, original)) {
+			// 별도 모듈에 Mapper가 추가된 환경을 재현하기 위해 테스트 리소스를 클래스패스 루트로 등록한다.
+			Thread.currentThread().setContextClassLoader(extensionLoader);
+			MockEnvironment env = new MockEnvironment().withProperty("Globals.DbType", "testdb")
+					.withProperty("Globals.testdb.DriverClassName", "org.hsqldb.jdbc.JDBCDriver")
+					.withProperty("Globals.testdb.Url", "jdbc:hsqldb:mem:extension-test;shutdown=true")
+					.withProperty("Globals.testdb.UserName", "sa")
+					.withProperty("Globals.testdb.Password", "");
+			EgovConfigAppDatasource datasourceConfig = new EgovConfigAppDatasource(env);
+			datasourceConfig.init();
+			try (HikariDataSource dataSource = (HikariDataSource) datasourceConfig.dataSource()) {
+				EgovConfigAppMapper mapperConfig = new EgovConfigAppMapper(dataSource, env);
+				mapperConfig.init();
+				SqlSessionFactoryBean factory = mapperConfig.sqlSession();
+				factory.afterPropertiesSet();
+				assertThat(dataSource.getHikariPoolMXBean()).isNull();
+				try (SqlSession session = factory.getObject().openSession()) {
+					assertThat(session.<Integer>selectOne("extensionTest.selectOne")).isEqualTo(1);
+				}
+			}
+		} finally {
+			// 다른 테스트의 리소스 검색에 영향을 주지 않도록 원래 클래스 로더를 반드시 복원한다.
+			Thread.currentThread().setContextClassLoader(original);
+		}
+	}
+}

--- a/src/test/resources/db-extension/egovframework/mapper/let/config/Extension_SQL_testdb.xml
+++ b/src/test/resources/db-extension/egovframework/mapper/let/config/Extension_SQL_testdb.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="extensionTest">
+    <select id="selectOne" resultType="int">VALUES (1)</select>
+</mapper>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [  ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [  ] 기능추가 Adding features
- [  ] 기타 Others

## 수정된 소스 내용 Modified source

Globals.DbType에 오타가 있거나 필수 JDBC 설정이 누락될 경우, NPE 또는 연결 시점의 오류가 발생해 원인을 파악하기 어려웠습니다.
초기화 단계에서 설정을 검증하고, 문제가 있는 설정 키와 확인 방법을 에러 메시지로 안내하도록 수정했습니다.

※ `application.properties`에 기본으로 등록되지 않은 데이터베이스도 JDBC 설정, 드라이버, Mapper를 추가하면 사용할 수 있습니다.

- `Globals.DbType`의 누락·공백·허용 형식 검증 추가
- 외부 DB의 드라이버 클래스명과 URL 검증 및 누락된 프로퍼티 일괄 안내
- 드라이버 로딩 및 생성 실패 시, 원인 예외를 보존하고 설정 확인 방법 안내
- 선택한 DB의 Mapper가 없으면 명시적인 오류 발생
- `classpath*:` 검색으로 추가 클래스패스의 Mapper 지원

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [  ] 수동 테스트 Manual testing

검증 결과:

- 테스트 파일 경로: src/test/java/egovframework/com/config/EgovConfigAppDatasourceTest.java, src/test/java/egovframework/com/config/EgovConfigAppMapperTest.java
- 신규 테스트 34개 통과, 전체 테스트 180개 통과, JAR 패키징 성공

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

백엔드 코드 변경으로 브라우저 테스트는 수행하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음. JUnit 테스트 및 Maven 빌드 결과로 검증했습니다.