### PR TITLE
test(jwt): 인증 실패 테스트 보강

### DIFF
--- a/src/test/java/egovframework/com/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/egovframework/com/jwt/JwtAuthenticationFilterTest.java
@@ -1,22 +1,31 @@
 package egovframework.com.jwt;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import egovframework.com.cmm.LoginVO;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -40,6 +49,11 @@ public class JwtAuthenticationFilterTest {
         SecurityContextHolder.clearContext();
     }
 
+    @AfterEach
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
     @DisplayName("유효한 토큰이 주어지면 인증 객체가 설정된다")
     @Test
     public void testValidTokenSetsAuthentication() throws Exception {
@@ -58,11 +72,18 @@ public class JwtAuthenticationFilterTest {
         assertEquals("user1", ((LoginVO) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId());
     }
 
-    @DisplayName("유효하지 않은 토큰이 주어지면 인증 객체가 설정되지 않는다")
-    @Test
-    public void testInvalidTokenDoesNotSetAuthentication() throws Exception {
+    @DisplayName("유효하지 않은 토큰은 기존 인증을 제거하고 401 응답으로 요청을 차단한다")
+    @ParameterizedTest(name = "기존 인증 존재: {0}")
+    @ValueSource(booleans = {false, true})
+    public void testInvalidTokenRejectsRequest(boolean hasExistingAuthentication) throws Exception {
         String invalidToken = "invalid.jwt.token";
         request.addHeader("Authorization", invalidToken);
+
+        if (hasExistingAuthentication) {
+            SecurityContextHolder.getContext().setAuthentication(
+                    UsernamePasswordAuthenticationToken.authenticated(
+                            "previous-user", null, AuthorityUtils.createAuthorityList("ROLE_USER")));
+        }
 
         when(jwtTokenUtil.getLoginVOFromToken(invalidToken))
                 .thenThrow(new InvalidJwtException("Invalid token"));
@@ -70,6 +91,12 @@ public class JwtAuthenticationFilterTest {
         filter.doFilterInternal(request, response, filterChain);
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+
+        JsonNode body = new ObjectMapper().readTree(response.getContentAsString());
+        assertEquals("401", body.path("resultCode").textValue());
+        assertEquals("invalid or expired token", body.path("resultMessage").textValue());
+        verifyNoInteractions(filterChain);
     }
 }
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

JWT 인증 실패 처리의 회귀 테스트를 보강했습니다.

## 수정된 소스 내용 Modified source

- 기존 인증의 유무에 따라 인증 정보 제거, HTTP 401 및 오류 JSON 반환, 다음 필터 미호출을 검증하도록 `JwtAuthenticationFilterTest`를 보강했습니다.
- 테스트 종료 후 인증 컨텍스트를 정리하도록 했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 다음 명령으로 148개 테스트 통과 및 빌드 성공을 확인했습니다. 브라우저 태그 테스트는 CI와 동일하게 제외했습니다.

```bash
mvn -B package --file pom.xml -DexcludedGroups=browser
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 브라우저 테스트는 진행하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

자동화 테스트 변경으로 별도 첨부 자료는 없습니다.
