### PR TITLE
test(jwt): 만료·서명 검증 테스트 보강

### DIFF
--- a/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
+++ b/src/test/java/egovframework/com/jwt/EgovJwtTokenUtilTest.java
@@ -2,19 +2,27 @@ package egovframework.com.jwt;
 
 import egovframework.com.cmm.LoginVO;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.Base64;
+import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class EgovJwtTokenUtilTest {
 
     private final EgovJwtTokenUtil jwtTokenUtil = new EgovJwtTokenUtil();
+    private String secretKeyString;
 
     // secretKeyString 은 @Value("${Globals.jwt.secret}") 로 주입되나, 본 단위 테스트는
     // 스프링 컨텍스트 없이 인스턴스를 직접 생성한다. 하드코딩 시크릿을 남기지 않도록
@@ -23,8 +31,8 @@ class EgovJwtTokenUtilTest {
     void setUp() {
         byte[] randomKey = new byte[48];
         new SecureRandom().nextBytes(randomKey);
-        ReflectionTestUtils.setField(jwtTokenUtil, "secretKeyString",
-                Base64.getEncoder().encodeToString(randomKey));
+        secretKeyString = Base64.getEncoder().encodeToString(randomKey);
+        ReflectionTestUtils.setField(jwtTokenUtil, "secretKeyString", secretKeyString);
     }
 
     @DisplayName("올바른 토큰을 입력했을 때, LoginVO 객체를 반환한다.")
@@ -91,6 +99,48 @@ class EgovJwtTokenUtilTest {
         assertThrows(InvalidJwtException.class, () -> {
             jwtTokenUtil.getLoginVOFromToken(token);
         });
+    }
+
+    @DisplayName("서명은 유효하지만 만료된 토큰은 InvalidJwtException 예외가 발생한다.")
+    @Test
+    void testExpiredTokenThrowsInvalidJwtException() {
+        // given
+        SecretKey signingKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+        String token = Jwts.builder()
+                .claim("id", "testUser")
+                .expiration(Date.from(Instant.now().minusSeconds(3600)))
+                .signWith(signingKey)
+                .compact();
+
+        // 서명이나 ID 누락이 아닌 만료 때문에 거부되는 토큰인지 확인한다.
+        ExpiredJwtException expired = assertThrows(ExpiredJwtException.class,
+                () -> jwtTokenUtil.getAllClaimsFromToken(token));
+        assertEquals("testUser", expired.getClaims().get("id", String.class));
+
+        // when / then
+        assertThrows(InvalidJwtException.class, () -> jwtTokenUtil.getLoginVOFromToken(token));
+    }
+
+    @DisplayName("다른 키로 서명된 토큰은 InvalidJwtException 예외가 발생한다.")
+    @Test
+    void testTokenSignedWithDifferentKeyThrowsInvalidJwtException() {
+        // given
+        byte[] otherKeyBytes = secretKeyString.getBytes(StandardCharsets.UTF_8);
+        otherKeyBytes[0] ^= 1;
+        SecretKey otherSigningKey = Keys.hmacShaKeyFor(otherKeyBytes);
+        String token = Jwts.builder()
+                .claim("id", "testUser")
+                .expiration(Date.from(Instant.now().plusSeconds(3600)))
+                .signWith(otherSigningKey)
+                .compact();
+
+        // 서명에 사용한 키로는 정상 검증되는 토큰인지 확인한다.
+        Claims claims = Jwts.parser().verifyWith(otherSigningKey).build()
+                .parseSignedClaims(token).getPayload();
+        assertEquals("testUser", claims.get("id", String.class));
+
+        // when / then
+        assertThrows(InvalidJwtException.class, () -> jwtTokenUtil.getLoginVOFromToken(token));
     }
 
     @DisplayName("Id가 포함되지 않은 토큰을 입력했을 때, InvalidJwtException 예외가 발생한다.")


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

JWT 만료·서명 검증의 회귀 테스트를 보강했습니다.

## 수정된 소스 내용 Modified source

`EgovJwtTokenUtilTest`에 만료된 토큰과 다른 키로 서명된 토큰을 거부하는 테스트 2개를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 149개 테스트 통과 및 빌드 성공을 확인했습니다. 브라우저 태그 테스트는 제외했습니다.

```bash
mvn -B clean package --file pom.xml -DexcludedGroups=browser
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

자동화 테스트 변경으로 별도 첨부 자료는 없습니다.
