### PR TITLE
fix(bbs): 게시판 첨부파일 크기 설정 키 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiController.java
@@ -184,7 +184,7 @@ public class EgovBBSAttributeManageApiController {
 		bbsAttributeInsertRequestDTO.setFrstRegisterId(loginVO.getUniqId());
 		bbsAttributeInsertRequestDTO.setUseAt("Y");
 		bbsAttributeInsertRequestDTO.setTrgetId("SYSTEMDEFAULT_REGIST");
-		bbsAttributeInsertRequestDTO.setPosblAtchFileSize(propertyService.getString("posblAtchFileSize"));
+		bbsAttributeInsertRequestDTO.setPosblAtchFileSize(propertyService.getString("Globals.posblAtchFileSize"));
 
 		bbsAttrbService.insertBBSMastetInf(bbsAttributeInsertRequestDTO);
 
@@ -265,7 +265,7 @@ public class EgovBBSAttributeManageApiController {
 		}
 
 		bbsAttributeUpdateRequestDTO.setLastUpdusrId(loginVO.getUniqId());
-		bbsAttributeUpdateRequestDTO.setPosblAtchFileSize(propertyService.getString("posblAtchFileSize"));
+		bbsAttributeUpdateRequestDTO.setPosblAtchFileSize(propertyService.getString("Globals.posblAtchFileSize"));
 		bbsAttrbService.updateBBSMasterInf(bbsAttributeUpdateRequestDTO);
 
 		return IntermediateResultVO.success(null);

--- a/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiControllerAttachmentSizeTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiControllerAttachmentSizeTest.java
@@ -1,0 +1,105 @@
+package egovframework.let.cop.bbs.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.springframework.validation.BeanPropertyBindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.IntermediateResultVO;
+import egovframework.com.config.EgovConfigAppProperties;
+import egovframework.let.cop.bbs.dto.request.BbsAttributeInsertRequestDTO;
+import egovframework.let.cop.bbs.dto.request.BbsAttributeUpdateRequestDTO;
+import egovframework.let.cop.bbs.service.EgovBBSAttributeManageService;
+
+class EgovBBSAttributeManageApiControllerAttachmentSizeTest {
+
+    private EgovBBSAttributeManageService bbsAttrbService;
+    private LoginVO loginVO;
+
+    @BeforeEach
+    void setUp() {
+        bbsAttrbService = mock(EgovBBSAttributeManageService.class);
+        loginVO = new LoginVO();
+        loginVO.setUniqId("USRCNFRM_00000000001");
+    }
+
+    @DisplayName("게시판 등록 시 설정된 첨부파일 크기를 서비스에 전달한다")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "10485760")
+    void insertUsesConfiguredAttachmentSize(String overrideSize) throws Exception {
+        try (AnnotationConfigApplicationContext context = createPropertiesContext(overrideSize)) {
+            EgovBBSAttributeManageApiController controller = createController(context);
+            BbsAttributeInsertRequestDTO request = new BbsAttributeInsertRequestDTO();
+            request.setBbsNm("테스트 게시판");
+            request.setBbsIntrcn("첨부파일 크기 설정 검증");
+            request.setBbsTyCode("BBST01");
+            request.setBbsAttrbCode("BBSA02");
+
+            IntermediateResultVO<?> result = controller.insertBBSMasterInf(request,
+                    new BeanPropertyBindingResult(request, "request"), loginVO);
+
+            ArgumentCaptor<BbsAttributeInsertRequestDTO> captor =
+                    ArgumentCaptor.forClass(BbsAttributeInsertRequestDTO.class);
+            verify(bbsAttrbService).insertBBSMastetInf(captor.capture());
+            assertEquals(context.getEnvironment().getRequiredProperty("Globals.posblAtchFileSize"),
+                    captor.getValue().getPosblAtchFileSize());
+            assertEquals(200, result.getResultCode());
+        }
+    }
+
+    @DisplayName("게시판 수정 시 설정된 첨부파일 크기를 서비스에 전달한다")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "10485760")
+    void updateUsesConfiguredAttachmentSize(String overrideSize) throws Exception {
+        try (AnnotationConfigApplicationContext context = createPropertiesContext(overrideSize)) {
+            EgovBBSAttributeManageApiController controller = createController(context);
+            BbsAttributeUpdateRequestDTO request = new BbsAttributeUpdateRequestDTO();
+            request.setBbsId("BBSMSTR_000000000001");
+            request.setBbsNm("테스트 게시판");
+            request.setBbsIntrcn("첨부파일 크기 설정 검증");
+            request.setBbsTyCode("BBST01");
+            request.setBbsAttrbCode("BBSA02");
+
+            IntermediateResultVO<?> result = controller.updateBBSMasterInf(request,
+                    new BeanPropertyBindingResult(request, "request"), loginVO);
+
+            ArgumentCaptor<BbsAttributeUpdateRequestDTO> captor =
+                    ArgumentCaptor.forClass(BbsAttributeUpdateRequestDTO.class);
+            verify(bbsAttrbService).updateBBSMasterInf(captor.capture());
+            assertEquals(context.getEnvironment().getRequiredProperty("Globals.posblAtchFileSize"),
+                    captor.getValue().getPosblAtchFileSize());
+            assertEquals(200, result.getResultCode());
+        }
+    }
+
+    private AnnotationConfigApplicationContext createPropertiesContext(String overrideSize) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        TestPropertySourceUtils.addPropertiesFilesToEnvironment(context, "classpath:application.properties");
+        if (overrideSize != null) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context,
+                    "Globals.posblAtchFileSize=" + overrideSize);
+        }
+        context.register(EgovConfigAppProperties.class);
+        context.refresh();
+        return context;
+    }
+
+    private EgovBBSAttributeManageApiController createController(AnnotationConfigApplicationContext context) {
+        return new EgovBBSAttributeManageApiController(bbsAttrbService, mock(EgovCmmUseService.class),
+                context.getBean(EgovPropertyService.class));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

게시판 등록·수정 코드에서 첨부파일 크기를 조회하는 설정 키가 실제 등록된 키와 달라, 설정값이 있어도 서비스에 null이 전달되고 있었습니다. 조회 키를 `Globals.posblAtchFileSize`로 일치시키고, 기본값과 변경한 설정값이 모두 정상적으로 전달되는지 검증하는 테스트를 추가했습니다.

## 수정된 소스 내용 Modified source

- 설정 조회 키를 `Globals.posblAtchFileSize`로 수정했습니다.
- 등록·수정 각각 기본값과 변경한 설정값의 전달을 확인하는 테스트 4개를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

수정 전 오류를 재현했으며, 수정 후 JDK 17에서 브라우저 테스트를 제외한 전체 151개 테스트와 빌드가 성공했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

별도 첨부 자료는 없습니다.
