### PR TITLE
fix(member): 아이디 중복 확인 문자 깨짐 수정

### DIFF
--- a/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
+++ b/src/main/java/egovframework/let/uss/umt/web/EgovMberManageApiController.java
@@ -602,7 +602,6 @@ public class EgovMberManageApiController {
 	@GetMapping("/etc/member_checkid/{checkid}")
 	public ResultVO checkIdDplct(@PathVariable("checkid") String checkId) throws Exception {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
-		checkId = new String(checkId.getBytes("ISO-8859-1"), "UTF-8");
 
 		if (checkId == null || checkId.equals("")) {
 			return resultVoHelper.buildFromMap(resultMap, ResponseCode.INPUT_CHECK_ERROR);

--- a/src/test/java/egovframework/let/uss/umt/web/EgovMberManageApiControllerTest.java
+++ b/src/test/java/egovframework/let/uss/umt/web/EgovMberManageApiControllerTest.java
@@ -1,0 +1,60 @@
+package egovframework.let.uss.umt.web;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.uss.umt.service.EgovMberManageService;
+
+@ExtendWith(MockitoExtension.class)
+class EgovMberManageApiControllerTest {
+
+    @Mock
+    private EgovMberManageService mberManageService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        EgovMberManageApiController controller = new EgovMberManageApiController(
+                mberManageService, mock(EgovCmmUseService.class), mock(EgovPropertyService.class),
+                new ResultVoHelper());
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @DisplayName("아이디 중복 확인 시 요청한 문자열과 중복 결과를 유지한다")
+    @ParameterizedTest(name = "ID={0}, 중복 개수={1}")
+    @CsvSource({
+            "reviewuser, 0", "reviewuser, 1",
+            "홍길동, 0", "홍길동, 1",
+            "café, 0", "café, 1"
+    })
+    void checkIdDplctPreservesRequestedId(String checkId, int usedCnt) throws Exception {
+        when(mberManageService.checkIdDplct(anyString())).thenReturn(usedCnt);
+
+        mockMvc.perform(get("/etc/member_checkid/{checkid}", checkId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value(200))
+                .andExpect(jsonPath("$.result.checkId").value(checkId))
+                .andExpect(jsonPath("$.result.usedCnt").value(usedCnt));
+
+        verify(mberManageService).checkIdDplct(checkId);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

회원가입·회원등록 화면에서 한글 등 비ASCII 문자가 포함된 아이디를 중복 확인하면, 백엔드의 불필요한 인코딩 변환으로 문자열이 깨져 다른 아이디로 조회되고 있었습니다. 요청한 아이디 그대로 중복 여부를 확인하도록 수정했습니다.

## 수정된 소스 내용 Modified source

- 아이디 중복 확인 API의 ISO-8859-1 → UTF-8 재변환을 제거했습니다.
- 영문·한글·라틴 문자 아이디의 서비스 전달값과 응답을 확인하는 테스트 6개를 추가했습니다. 중복 여부가 0과 1인 경우를 각각 검증합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

수정 전 문자 깨짐을 재현했으며, 수정 후 JDK 17에서 브라우저 테스트를 제외한 전체 153개 테스트와 빌드가 성공했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

별도 첨부 자료는 없습니다.
