### PR TITLE
fix: 존재하지 않는 게시물을 조회·수정·삭제하면 서버 오류가 나는 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSManageApiController.java
@@ -211,7 +211,14 @@ public class EgovBBSManageApiController {
 		//----------------------------
 		BbsFileAtchResponseDTO bbsFileAtchResponseDTO = bbsAttrbService.selectBBSMasterInf(bbsManageDetailBoardRequestDTO.getBbsId(), uniqId, BbsDetailRequestType.LIST);
 
-		BbsManageDetailResponseDTO bbsManageDetailResponseDTO = bbsMngService.selectBoardArticle(bbsManageDetailBoardRequestDTO)
+		BbsManageDetailResponseDTO article = bbsMngService.selectBoardArticle(bbsManageDetailBoardRequestDTO);
+		if (article == null) {
+			// 존재하지 않는 게시물이다. 회원 조회(EgovMberManageApiController)와 같이
+			// 결과를 비워서 돌려준다.
+			return IntermediateResultVO.success(null);
+		}
+
+		BbsManageDetailResponseDTO bbsManageDetailResponseDTO = article
 				.toBuilder()
 				.brdMstrVO(bbsFileAtchResponseDTO)
 				.sessionUniqId(uniqId)

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceImpl.java
@@ -125,6 +125,14 @@ public class EgovBBSManageServiceImpl extends EgovAbstractServiceImpl implements
 		}
 
 		BoardVO vo = bbsMngDAO.selectBoardArticle(boardVO);
+
+		// 조회 결과가 없으면 null 을 돌려준다. 호출부의 소유권 검증(article == null)이
+		// 이 값을 전제로 작성돼 있는데, 그 앞에서 DTO 변환이 NullPointerException 을 내
+		// 지금까지 그 분기에 도달하지 못했다.
+		if (vo == null) {
+			return null;
+		}
+
 		BbsManageDetailResponseDTO bbsManageDetailResponseDTO;
 
 		// 2021-06-01 신용호 추가

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceMissingArticleTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSManageServiceMissingArticleTest.java
@@ -1,0 +1,96 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+import egovframework.let.cop.bbs.domain.repository.BBSManageDAO;
+import egovframework.let.cop.bbs.dto.request.BbsManageDetailBoardRequestDTO;
+import egovframework.let.cop.bbs.dto.response.BbsManageDetailResponseDTO;
+
+/**
+ * 존재하지 않는 게시물을 조회할 때 서비스가 null 을 돌려주는지 검증한다.
+ *
+ * <p>호출부의 소유권 검증은 {@code article == null || article.getBoardVO() == null} 로
+ * 작성돼 있는데, 그 앞에서 DTO 변환이 NullPointerException 을 내 그 분기에 도달하지
+ * 못했다. 그래서 삭제된 게시물을 수정·삭제·조회하면 500 이 반환됐다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovBBSManageServiceMissingArticleTest {
+
+    @Mock
+    private BBSManageDAO bbsMngDAO;
+
+    @Mock
+    private EgovFileMngService fileService;
+
+    @Mock
+    private EgovCryptoService cryptoService;
+
+    @Mock
+    private EgovIdGnrService egovNttIdGnrService;
+
+    @InjectMocks
+    private EgovBBSManageServiceImpl egovBBSManageService;
+
+    private BbsManageDetailBoardRequestDTO request() {
+        return BbsManageDetailBoardRequestDTO.builder()
+                .bbsId("BBSMSTR_AAAAAAAAAAAA")
+                .nttId(999999L)
+                .plusCount(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("게시물이 없으면 예외 대신 null 을 돌려준다")
+    void returnsNullWhenArticleDoesNotExist() throws Exception {
+        when(bbsMngDAO.selectBoardArticle(any(BoardVO.class))).thenReturn(null);
+
+        BbsManageDetailResponseDTO result = egovBBSManageService.selectBoardArticle(request());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("게시물이 없으면 첨부파일 조회로 넘어가지 않는다")
+    void doesNotLookUpAttachmentsWhenArticleDoesNotExist() throws Exception {
+        when(bbsMngDAO.selectBoardArticle(any(BoardVO.class))).thenReturn(null);
+
+        assertThatCode(() -> egovBBSManageService.selectBoardArticle(request()))
+                .doesNotThrowAnyException();
+
+        verify(fileService, never()).selectFileInfs(any());
+    }
+
+    @Test
+    @DisplayName("게시물이 있으면 기존과 같이 내용을 담아 돌려준다")
+    void returnsArticleWhenItExists() throws Exception {
+        BoardVO vo = new BoardVO();
+        vo.setBbsId("BBSMSTR_AAAAAAAAAAAA");
+        vo.setNttId(1L);
+        vo.setNttSj("제목");
+        vo.setFrstRegisterId("USER000000000000001");
+        when(bbsMngDAO.selectBoardArticle(any(BoardVO.class))).thenReturn(vo);
+
+        BbsManageDetailResponseDTO result = egovBBSManageService.selectBoardArticle(request());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getBoardVO()).isNotNull();
+        assertThat(result.getBoardVO().getNttSj()).isEqualTo("제목");
+        assertThat(result.getBoardVO().getFrstRegisterId()).isEqualTo("USER000000000000001");
+    }
+}

--- a/src/test/java/egovframework/let/cop/bbs/web/EgovBBSManageApiControllerMissingArticleTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/web/EgovBBSManageApiControllerMissingArticleTest.java
@@ -1,0 +1,36 @@
+package egovframework.let.cop.bbs.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 존재하지 않는 게시물을 조회했을 때 서버 오류가 나지 않는지 검증한다.
+ *
+ * <p>서비스가 조회 결과 없음을 null 로 돌려주지 않으면 DTO 변환에서
+ * NullPointerException 이 나 HTTP 500 이 반환된다. 상세 화면에서 새로고침을 하거나
+ * 삭제된 게시물을 다시 열면 재현된다.</p>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class EgovBBSManageApiControllerMissingArticleTest {
+
+    /** 시드에 존재하는 공지사항 게시판. */
+    private static final String SEEDED_BBS_ID = "BBSMSTR_AAAAAAAAAAAA";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("존재하지 않는 게시물 상세 조회가 서버 오류로 끝나지 않는다")
+    void missingArticleDetailDoesNotReturnServerError() throws Exception {
+        mockMvc.perform(get("/board/{bbsId}/{nttId}", SEEDED_BBS_ID, "99999999"))
+                .andExpect(status().is(org.springframework.http.HttpStatus.OK.value()));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBBSManageServiceImpl.selectBoardArticle` 이 DAO 조회 결과가 없어도 그대로 DTO 변환에 넘겨 `BbsManageDetailItemResponseDTO.from(null)` 에서 `NullPointerException` 이 발생합니다. 삭제된 게시물을 다시 열거나 상세 화면에서 새로고침하면 HTTP 500 이 반환됩니다.

호출부는 조회 결과 없음을 `null` 로 받는다는 전제로 **이미 작성돼 있습니다.**

```java
// EgovBBSManageApiController 수정 경로·삭제 경로
if (article == null || article.getBoardVO() == null || ...) -> AUTH_ERROR

// EgovFileMngApiController.resolveFileOwner
if (res != null && res.getBoardVO() != null && ...)
```

세 곳이 `null` 검사를 하고 있으나 그 앞에서 예외가 나기 때문에 **어느 분기도 실행된 적이 없습니다.**

서비스가 조회 결과가 없을 때 `null` 을 돌려주도록 했습니다. 이것으로 위 세 곳의 검사가 의도대로 동작합니다. 상세 조회 경로는 반환값에 곧바로 `toBuilder` 를 호출하고 있어 그쪽에도 `null` 처리를 넣었고, 응답은 회원 조회(`EgovMberManageApiController`)와 같이 결과를 비워서 돌려줍니다. `ResponseCode` 에 없는 대상 코드를 추가하는 방법도 검토했으나 열거형에 응답 코드를 늘리는 대신 같은 저장소에 이미 있는 관례를 따랐습니다.

`selectBoardArticle` 호출처는 저장소 전체에서 네 곳이고 위 세 곳과 상세 조회 경로입니다. **네 곳 모두 `null` 을 처리하므로 다른 경로에 영향이 없습니다.**

이번 수정은 게시물 조회·수정·삭제 세 경로만 다룹니다. 게시판 마스터와 사용정보, 일정 상세의 같은 유형과 숫자가 아닌 게시물 번호에서 나는 `NumberFormatException` 은 응답 형태 변경이 필요해 포함하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovBBSManageServiceMissingArticleTest` 3건과 `EgovBBSManageApiControllerMissingArticleTest` 1건을 추가했습니다. 앞은 서비스가 `null` 을 돌려주는지와 첨부파일 조회로 넘어가지 않는지, 게시물이 있으면 기존과 같은지를 확인하고, 뒤는 시드 게시판의 없는 게시물 번호로 `GET /board/{bbsId}/{nttId}` 를 호출해 서버 오류가 아닌지 확인합니다.

본체 수정만 되돌리면 4건 중 3건이 실패합니다. 서비스 두 건은 `NullPointerException` 이고 컨트롤러 건은 `Request processing failed: java.lang.NullPointerException` 입니다.

147건에서 151건이 되며 늘어난 4건이 모두 통과합니다. 새로 실패하는 테스트는 없습니다. 워크플로와 같은 `-DexcludedGroups=browser` 로 실행했습니다. JDK 17, Maven 3.9.9 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

응답 코드 변경이라 JUnit 으로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다. 대신 없는 게시물 번호로 상세 조회했을 때의 응답을 정리했습니다.

| 요청 | 수정 전 | 수정 후 |
| --- | --- | --- |
| `GET /board/{시드 게시판}/99999999` | `NullPointerException`, 500 | 200, 결과 비움 |
| `PATCH /board/{bbsId}/{없는 nttId}` | `NullPointerException`, 500 | `AUTH_ERROR` |
| `DELETE /board/{bbsId}/{없는 nttId}` | `NullPointerException`, 500 | `AUTH_ERROR` |
