### PR TITLE
fix(bbs): 게시판 사용 설정 변경 시 현재 수정자 기록

### DIFF
--- a/src/main/java/egovframework/let/cop/com/web/EgovBBSUseInfoManageApiController.java
+++ b/src/main/java/egovframework/let/cop/com/web/EgovBBSUseInfoManageApiController.java
@@ -264,6 +264,7 @@ public class EgovBBSUseInfoManageApiController {
 	) throws Exception {
 		
 		bdUseVO.setBbsId(bbsId);
+		bdUseVO.setLastUpdusrId(loginVO.getUniqId());
 		bbsUseService.updateBBSUseInf(bdUseVO);
 
 		return resultVoHelper.buildFromMap(new HashMap<String, Object>(), ResponseCode.SUCCESS);

--- a/src/test/java/egovframework/let/cop/com/web/EgovBBSUseInfoManageApiControllerTest.java
+++ b/src/test/java/egovframework/let/cop/com/web/EgovBBSUseInfoManageApiControllerTest.java
@@ -1,0 +1,106 @@
+package egovframework.let.cop.com.web;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.cop.bbs.service.EgovBBSAttributeManageService;
+import egovframework.let.cop.com.service.BoardUseInf;
+import egovframework.let.cop.com.service.EgovBBSUseInfoManageService;
+
+@ExtendWith(MockitoExtension.class)
+class EgovBBSUseInfoManageApiControllerTest {
+
+    @Mock
+    private EgovBBSUseInfoManageService bbsUseService;
+
+    @Mock
+    private EgovPropertyService propertyService;
+
+    @Mock
+    private EgovBBSAttributeManageService bbsAttrbService;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        EgovBBSUseInfoManageApiController controller = new EgovBBSUseInfoManageApiController(
+                bbsUseService, propertyService, bbsAttrbService, new ResultVoHelper());
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .build();
+
+        LoginVO loginVO = new LoginVO();
+        loginVO.setUniqId("CURRENT_ADMIN");
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                loginVO, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @ParameterizedTest(name = "[{index}] 요청 수정자={0}, 사용 여부={1}")
+    @MethodSource("updateRequests")
+    void updateUsesAuthenticatedEditor(String requestedEditor, String useAt) throws Exception {
+        Map<String, String> request = new HashMap<>();
+        request.put("bbsId", "BBS_FROM_BODY");
+        request.put("trgetId", "SYSTEM_DEFAULT_BOARD");
+        request.put("useAt", useAt);
+        if (requestedEditor != null) {
+            request.put("lastUpdusrId", requestedEditor);
+        }
+
+        mockMvc.perform(put("/bbsUseInf/{bbsId}", "BBS_FROM_PATH")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value(200));
+
+        ArgumentCaptor<BoardUseInf> captor = ArgumentCaptor.forClass(BoardUseInf.class);
+        verify(bbsUseService).updateBBSUseInf(captor.capture());
+        BoardUseInf updated = captor.getValue();
+        assertAll(
+                () -> assertEquals("CURRENT_ADMIN", updated.getLastUpdusrId()),
+                () -> assertEquals("BBS_FROM_PATH", updated.getBbsId()),
+                () -> assertEquals("SYSTEM_DEFAULT_BOARD", updated.getTrgetId()),
+                () -> assertEquals(useAt, updated.getUseAt()));
+    }
+
+    private static Stream<Arguments> updateRequests() {
+        return Stream.of(null, "", "PREVIOUS_ADMIN")
+                .flatMap(editor -> Stream.of("Y", "N").map(useAt -> Arguments.of(editor, useAt)));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

게시판 사용 여부를 변경할 때 로그인 사용자를 수정자로 설정하지 않아, 요청에 수정자 값이 없으면 빈값이 저장되거나 전달된 과거 수정자 값이 남을 수 있었습니다. 현재 로그인한 관리자를 수정자로 기록하도록 수정했습니다.

## 수정된 소스 내용 Modified source

- 사용 설정 수정 시 인증된 사용자의 `uniqId`를 `lastUpdusrId`에 설정했습니다.
- 수정자 누락·빈값·다른 ID와 사용/미사용 조합을 확인하는 테스트 6개를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 브라우저 그룹을 제외한 전체 153개 테스트와 빌드가 통과했습니다. 별도 HTTP·HSQL 통합 검증 5개로 실제 수정자 저장값과 익명·일반 사용자 요청 차단 및 DB 무변경을 확인했습니다.

React·Chrome 화면 자동 검증으로 사용 여부 저장과 재조회도 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

갤러리를 미사용으로 변경한 뒤 목록에 ‘사용안함’이 표시되는 화면입니다. 수정자 DB 저장값은 화면에 표시되지 않으므로 별도 HTTP·HSQL 통합 검증으로 확인했습니다.

![게시판 미사용 저장 후 목록](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/ee9fb24b5aa5e90f4fb9fe2cd55b6de72d906ebc/screenshots/bbs-usage-disabled.png)
