### PR TITLE
fix(bbs): 답글 작성에 필요한 상세 응답 필드 복원

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageDetailItemResponseDTO.java
+++ b/src/main/java/egovframework/let/cop/bbs/dto/response/BbsManageDetailItemResponseDTO.java
@@ -50,6 +50,12 @@ public class BbsManageDetailItemResponseDTO extends BbsDetailResponseDTO {
     @Schema(description = "부모글번호", example = "0")
     private String parnts;
 
+    @Schema(description = "게시물 정렬순서", example = "1")
+    private long sortOrdr;
+
+    @Schema(description = "답글 깊이", example = "0")
+    private String replyLc;
+
     @Schema(description = "게시물 첨부파일 아이디", example = "FILE_000000000000001")
     private String atchFileId;
 
@@ -71,6 +77,8 @@ public class BbsManageDetailItemResponseDTO extends BbsDetailResponseDTO {
                 .frstRegisterPnttm(vo.getFrstRegisterPnttm())
                 .inqireCo(vo.getInqireCo())
                 .parnts(vo.getParnts())
+                .sortOrdr(vo.getSortOrdr())
+                .replyLc(vo.getReplyLc())
                 .atchFileId(vo.getAtchFileId())
                 .build();
     }

--- a/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSReplyDetailIntegrationTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSReplyDetailIntegrationTest.java
@@ -1,0 +1,164 @@
+package egovframework.let.cop.bbs.controller;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.let.cop.bbs.domain.model.Board;
+import egovframework.let.cop.bbs.domain.model.BoardMaster;
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+import egovframework.let.cop.bbs.domain.repository.BBSAttributeManageDAO;
+import egovframework.let.cop.bbs.domain.repository.BBSManageDAO;
+import egovframework.let.cop.bbs.dto.request.BbsManageDetailBoardRequestDTO;
+import egovframework.let.cop.bbs.service.EgovBBSManageService;
+
+@SpringBootTest
+@Transactional
+class EgovBBSReplyDetailIntegrationTest {
+
+    @Autowired
+    private EgovBBSManageApiController controller;
+
+    @Autowired
+    private EgovBBSManageService service;
+
+    @Autowired
+    private BBSManageDAO boardDAO;
+
+    @Autowired
+    private BBSAttributeManageDAO masterDAO;
+
+    @Autowired
+    @Qualifier("egovBBSMstrIdGnrService")
+    private EgovIdGnrService masterIdService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        LoginVO user = new LoginVO();
+        user.setUniqId("REPLY_TEST_ADMIN");
+        user.setName("답글 테스트 관리자");
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, null,
+                        List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @ParameterizedTest(name = "상세 응답으로 답글 등록: 부모 깊이 {0}")
+    @ValueSource(ints = {0, 1})
+    void replyFromDetailPreservesThreadOrderAndIncrementsDepth(int parentDepth) throws Exception {
+        String bbsId = createBoardMaster();
+        Board older = insertArticle(bbsId, "이전 글");
+        Board root = insertArticle(bbsId, "원글");
+        BoardVO parent = selectStoredArticle(bbsId, root.getNttId());
+        if (parentDepth == 1) {
+            Board existingReply = new Board();
+            existingReply.setBbsId(bbsId);
+            existingReply.setNttSj("기존 답글");
+            existingReply.setNttCn("기존 답글 내용");
+            existingReply.setReplyAt("Y");
+            existingReply.setReplyLc("1");
+            existingReply.setParnts(Long.toString(root.getNttId()));
+            existingReply.setSortOrdr(parent.getSortOrdr());
+            service.insertBoardArticle(existingReply);
+            parent = selectStoredArticle(bbsId, existingReply.getNttId());
+        }
+
+        JsonNode detail = objectMapper.readTree(objectMapper.writeValueAsString(
+                service.selectBoardArticle(BbsManageDetailBoardRequestDTO.builder()
+                        .bbsId(bbsId).nttId(parent.getNttId()).plusCount(false).build())))
+                .get("boardVO");
+
+        // React 답글 화면처럼 상세 응답을 복사하고 FormData 문자열로 전송한다.
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        detail.fields().forEachRemaining(field -> form.add(field.getKey(), field.getValue().asText()));
+        form.set("nttSj", "새 답글");
+        form.set("nttCn", "새 답글 내용");
+        form.set("inqireCo", "0");
+        form.set("atchFileId", "");
+
+        mockMvc.perform(multipart("/boardReply").params(form))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value(200));
+
+        BoardVO search = new BoardVO();
+        search.setBbsId(bbsId);
+        search.setSearchCnd("0");
+        search.setSearchWrd("");
+        search.setFirstIndex(0);
+        search.setRecordCountPerPage(10);
+        List<BoardVO> articles = boardDAO.selectBoardArticleList(search);
+        long replyId = articles.stream().filter(article -> "새 답글".equals(article.getNttSj()))
+                .findFirst().orElseThrow().getNttId();
+        BoardVO savedReply = selectStoredArticle(bbsId, replyId);
+        long parentId = parent.getNttId();
+        long parentSortOrder = parent.getSortOrdr();
+        List<Long> expectedOrder = parentDepth == 0
+                ? List.of(root.getNttId(), replyId, older.getNttId())
+                : List.of(root.getNttId(), parentId, replyId, older.getNttId());
+
+        assertAll(
+                () -> assertEquals(Long.toString(parentId), savedReply.getParnts()),
+                () -> assertEquals(parentSortOrder, savedReply.getSortOrdr()),
+                () -> assertEquals(Integer.toString(parentDepth + 1), savedReply.getReplyLc()),
+                () -> assertEquals(expectedOrder, articles.stream().map(BoardVO::getNttId).toList()));
+    }
+
+    private String createBoardMaster() throws Exception {
+        BoardMaster master = new BoardMaster();
+        master.setBbsId(masterIdService.getNextStringId());
+        master.setBbsNm("답글 상세 응답 테스트");
+        master.setPosblAtchFileSize("0");
+        masterDAO.insertBBSMasterInf(master);
+        return master.getBbsId();
+    }
+
+    private Board insertArticle(String bbsId, String title) throws Exception {
+        Board article = new Board();
+        article.setBbsId(bbsId);
+        article.setNttSj(title);
+        article.setNttCn(title + " 내용");
+        service.insertBoardArticle(article);
+        return article;
+    }
+
+    private BoardVO selectStoredArticle(String bbsId, long nttId) throws Exception {
+        BoardVO lookup = new BoardVO();
+        lookup.setBbsId(bbsId);
+        lookup.setNttId(nttId);
+        return boardDAO.selectBoardArticle(lookup);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

게시물 상세 응답에 정렬 순서와 답글 깊이가 빠져, 해당 응답을 복사해 답글을 작성하는 React 화면에서 부모글의 정보가 전달되지 않았습니다. 답글의 정렬 그룹과 중첩 깊이가 유지되도록 상세 응답을 보완했습니다.

## 수정된 소스 내용 Modified source

- 상세 응답 DTO에 `sortOrdr`, `replyLc`와 값 매핑을 추가했습니다.
- 상세 조회 → 답글 등록 → DB 저장·목록 순서를 확인하는 통합 테스트 2개를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 브라우저 그룹을 제외한 전체 149개 테스트와 빌드가 통과했습니다. 별도 HTTP·HSQL 통합 검증 9개로 중첩 답글, 같은 원글의 여러 답글, 다른 원글 그룹의 정렬·깊이와 익명 등록 차단을 확인했습니다.

React·Chrome 화면 자동 검증에서도 원글 → 답글 → 중첩 답글의 표시 순서와 API 응답이 일치했습니다. 기존에 잘못 저장된 답글 데이터의 보정은 포함하지 않습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

React 화면에서 작성한 원글 → 답글 → 중첩 답글이 차례로 표시되는 목록입니다. 부모 ID·정렬 그룹·깊이 0 → 1 → 2는 API 응답으로 함께 확인했습니다.

![원글과 답글 및 중첩 답글 목록](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/ee9fb24b5aa5e90f4fb9fe2cd55b6de72d906ebc/screenshots/bbs-reply-order.png)
