### PR TITLE
fix(auth): 관리자 암호 변경의 최소 길이 검증 추가

### DIFF
--- a/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
+++ b/src/main/java/egovframework/let/uat/esm/web/EgovSiteManagerApiController.java
@@ -111,6 +111,12 @@ public class EgovSiteManagerApiController {
 
 		String old_password = param.get("old_password");
 		String new_password = param.get("new_password");
+		if (new_password == null || new_password.length() < 6) {
+			resultVO.setResultCode(ResponseCode.INPUT_CHECK_ERROR.getCode());
+			resultVO.setResultMessage("신규 암호는 6자 이상이어야 합니다.");
+			return resultVO;
+		}
+
 		String login_id = user.getId();
 		Map<String,Object> resultMap = new HashMap<String,Object>();
 		// 저장 형식 = 이중해시. old/new 모두 동일 형식으로 비교/저장.

--- a/src/test/java/egovframework/let/uat/esm/web/EgovSiteManagerApiControllerTest.java
+++ b/src/test/java/egovframework/let/uat/esm/web/EgovSiteManagerApiControllerTest.java
@@ -1,0 +1,135 @@
+package egovframework.let.uat.esm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.ResponseCode;
+import egovframework.let.uat.esm.service.EgovSiteManagerService;
+import egovframework.let.utl.sim.service.EgovFileScrty;
+
+@ExtendWith(MockitoExtension.class)
+class EgovSiteManagerApiControllerTest {
+
+	private static final String LOGIN_ID = "test-admin";
+
+	@Mock
+	private EgovSiteManagerService siteManagerService;
+
+	@Captor
+	private ArgumentCaptor<Map<String, Object>> passwordMapCaptor;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		EgovSiteManagerApiController controller = new EgovSiteManagerApiController();
+		ReflectionTestUtils.setField(controller, "siteManagerService", siteManagerService);
+		mockMvc = MockMvcBuilders.standaloneSetup(controller)
+				.setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+				.build();
+
+		LoginVO user = new LoginVO();
+		user.setId(LOGIN_ID);
+		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+				user, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+	}
+
+	@AfterEach
+	void clearSecurityContext() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {"1", "12345"})
+	void rejectsNewPasswordShorterThanSixCharacters(String newPassword) throws Exception {
+		Map<String, String> request = new HashMap<>();
+		request.put("old_password", "old-password");
+		request.put("new_password", newPassword);
+
+		assertInputError(request);
+	}
+
+	@Test
+	void rejectsMissingNewPassword() throws Exception {
+		assertInputError(Map.of("old_password", "old-password"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"old, 123456", "old-password, 1234567", "old-password, ' 1234 '"})
+	void acceptsAtLeastSixCharactersAndPreservesPasswordHashing(String oldPassword, String newPassword)
+			throws Exception {
+		when(siteManagerService.updateAdminPassword(anyMap())).thenReturn(1);
+
+		updatePassword(Map.of("old_password", oldPassword, "new_password", newPassword))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.resultCode").value(ResponseCode.SUCCESS.getCode()));
+
+		verify(siteManagerService).updateAdminPassword(passwordMapCaptor.capture());
+		Map<String, Object> passwordMap = passwordMapCaptor.getValue();
+		assertEquals(LOGIN_ID, passwordMap.get("login_id"));
+		assertEquals(EgovFileScrty.encryptPasswordTwice(oldPassword, LOGIN_ID), passwordMap.get("old_password"));
+		assertEquals(EgovFileScrty.encryptPasswordTwice(newPassword, LOGIN_ID), passwordMap.get("new_password"));
+	}
+
+	@Test
+	void preservesSaveErrorWhenOldPasswordDoesNotMatch() throws Exception {
+		when(siteManagerService.updateAdminPassword(anyMap())).thenReturn(0);
+
+		updatePassword(Map.of("old_password", "wrong-password", "new_password", "123456"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.resultCode").value(ResponseCode.SAVE_ERROR.getCode()))
+				.andExpect(jsonPath("$.resultMessage").value(ResponseCode.SAVE_ERROR.getMessage()));
+		verify(siteManagerService).updateAdminPassword(anyMap());
+	}
+
+	private void assertInputError(Map<String, String> request) throws Exception {
+		updatePassword(request)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.resultCode").value(ResponseCode.INPUT_CHECK_ERROR.getCode()))
+				.andExpect(jsonPath("$.resultMessage").value("신규 암호는 6자 이상이어야 합니다."));
+		verifyNoInteractions(siteManagerService);
+	}
+
+	private ResultActions updatePassword(Map<String, String> request) throws Exception {
+		return mockMvc.perform(patch("/admin/password")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

관리자 암호 변경 API가 6자 미만의 신규 암호도 저장할 수 있었지만, React 로그인 화면은 6자 미만 입력을 차단하고 있었습니다. 변경 후 화면에서 다시 로그인할 수 없게 되는 문제를 막기 위해 신규 암호의 길이를 검사했습니다.

## 수정된 소스 내용 Modified source

- 신규 암호가 누락되거나 6자 미만이면 저장 전에 입력 오류 코드 900을 반환합니다.
- 잘못된 입력, 6자 경계값, 공백 유지와 기존 암호 확인을 검증하는 테스트 9개를 추가했습니다.

관련 React 변경: https://github.com/eGovFramework/egovframe-template-simple-react/pull/148

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 브라우저 그룹을 제외한 전체 156개 테스트와 빌드가 통과했습니다. 별도 HTTP·HSQL 통합 검증 11개로 입력 오류 시 DB 유지, 6자·한글·공백 포함 암호 변경 후 재로그인, 잘못된 기존 암호 및 권한 없는 요청 차단을 확인했습니다.

React·Chrome 화면 자동 검증에서도 정확히 6자로 변경한 뒤 기존 암호 로그인 실패와 새 암호 로그인 성공을 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

암호를 정확히 6자로 변경하고 로그아웃한 뒤 새 암호로 재로그인한 메인 화면입니다. 입력 검증 경고 화면의 캡처는 없으며, 해당 검증 결과는 위 테스트에 포함했습니다.

![신규 암호로 재로그인한 뒤 메인 화면](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/ee9fb24b5aa5e90f4fb9fe2cd55b6de72d906ebc/screenshots/admin-relogin-success.png)
