### PR TITLE
fix(file): 빈 첨부파일 다운로드 처리 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovFileDownloadController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovFileDownloadController.java
@@ -205,9 +205,8 @@ public class EgovFileDownloadController {
 			String streFileNm = EgovWebUtil.filePathBlackList(fvo.getStreFileNm());
 
 			File uFile = new File(fileStreCours, streFileNm);
-			long fSize = uFile.length();
 
-			if (fSize > 0) {
+			if (uFile.isFile()) {
 				//String mimetype = "application/x-msdownload";
 				String mimetype = "application/x-stuff";
 

--- a/src/test/java/egovframework/com/cmm/web/EgovFileDownloadControllerTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovFileDownloadControllerTest.java
@@ -1,0 +1,127 @@
+package egovframework.com.cmm.web;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.FileVO;
+
+class EgovFileDownloadControllerTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    private EgovFileDownloadController controller;
+    private EgovFileMngService fileService;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private Map<String, Object> parameters;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        fileService = mock(EgovFileMngService.class);
+        EgovCryptoService cryptoService = mock(EgovCryptoService.class);
+        controller = new EgovFileDownloadController();
+        ReflectionTestUtils.setField(controller, "fileService", fileService);
+        ReflectionTestUtils.setField(controller, "cryptoService", cryptoService);
+
+        byte[] encryptedFileId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
+        when(cryptoService.decrypt(eq(encryptedFileId), eq(EgovFileDownloadController.ALGORITM_KEY)))
+                .thenReturn("file-id".getBytes(StandardCharsets.UTF_8));
+        parameters = Map.of("atchFileId", Base64.getEncoder().encodeToString(encryptedFileId), "fileSn", "0");
+        request = new MockHttpServletRequest();
+        request.addHeader("User-Agent", "Chrome");
+        response = new MockHttpServletResponse();
+    }
+
+    @DisplayName("0바이트 첨부파일도 원본 파일명과 빈 본문으로 다운로드된다.")
+    @Test
+    void downloadsEmptyFile() throws Exception {
+        Files.createFile(temporaryDirectory.resolve("stored-file"));
+        givenFileInfo("stored-file", "empty.xlsx");
+
+        controller.cvplFileDownload(parameters, request, response);
+
+        assertDownload("empty.xlsx", new byte[0]);
+    }
+
+    @DisplayName("일반 첨부파일은 원본 파일명과 파일 바이트를 응답한다.")
+    @Test
+    void downloadsFileWithContent() throws Exception {
+        byte[] fileBytes = new byte[] {0, 1, 2, (byte) 255};
+        Files.write(temporaryDirectory.resolve("stored-file"), fileBytes);
+        givenFileInfo("stored-file", "sample.xlsx");
+
+        controller.cvplFileDownload(parameters, request, response);
+
+        assertDownload("sample.xlsx", fileBytes);
+    }
+
+    @DisplayName("저장된 실제 파일이 없으면 다운로드를 거부한다.")
+    @Test
+    void rejectsMissingFile() throws Exception {
+        givenFileInfo("missing-file", "sample.xlsx");
+
+        assertDownloadRejected();
+    }
+
+    @DisplayName("저장 경로가 디렉터리이면 다운로드를 거부한다.")
+    @Test
+    void rejectsDirectory() throws Exception {
+        Files.createDirectory(temporaryDirectory.resolve("directory"));
+        givenFileInfo("directory", "sample.xlsx");
+
+        assertDownloadRejected();
+    }
+
+    @DisplayName("삭제 등으로 첨부파일 정보가 조회되지 않으면 다운로드를 거부한다.")
+    @Test
+    void rejectsUnavailableFileInfo() throws Exception {
+        when(fileService.selectFileInf(any(FileVO.class))).thenReturn(null);
+
+        assertDownloadRejected();
+    }
+
+    private void givenFileInfo(String storedFileName, String originalFileName) throws Exception {
+        FileVO fileInfo = new FileVO();
+        fileInfo.setFileStreCours(temporaryDirectory.toString());
+        fileInfo.setStreFileNm(storedFileName);
+        fileInfo.setOrignlFileNm(originalFileName);
+        when(fileService.selectFileInf(any(FileVO.class))).thenReturn(fileInfo);
+    }
+
+    private void assertDownload(String originalFileName, byte[] expectedBytes) {
+        assertEquals(200, response.getStatus());
+        assertEquals("application/x-stuff", response.getContentType());
+        assertEquals("attachment; filename=" + originalFileName, response.getHeader("Content-Disposition"));
+        assertArrayEquals(expectedBytes, response.getContentAsByteArray());
+    }
+
+    private void assertDownloadRejected() {
+        assertThrows(EgovBizException.class, () -> controller.cvplFileDownload(parameters, request, response));
+        assertNull(response.getHeader("Content-Disposition"));
+        assertEquals(0, response.getContentAsByteArray().length);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

이름이 있는 0바이트 첨부파일은 업로드에 성공하지만, 다운로드 시 파일 크기가 0보다 큰지 검사하여 HTTP 500 오류가 발생합니다.

## 수정된 소스 내용 Modified source

- 파일 크기 대신 일반 파일 여부를 확인하여 0바이트 첨부파일도 원래 파일명으로 다운로드합니다.
- 빈 파일·일반 파일과 다운로드할 수 없는 첨부파일에 대한 테스트를 추가합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 전체 테스트: 152개 통과(신규 5개 포함) (`mvn -B package --file pom.xml -DexcludedGroups=browser`)
- 실제 HTTP 통합 검증: 실제 JWT·HSQL 환경에서 빈 파일·일반 파일·누락 파일·누락 정보·삭제 상태·디렉터리 6건 통과
- Chrome 자동 검증: React에서 두 파일을 업로드·다운로드하고 파일명 및 원본 바이트 일치 확인(0바이트 / 1,451바이트)

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전: 업로드된 빈 파일을 클릭하면 HTTP 500 오류가 발생합니다.

![수정 전 테스트](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/202c343ca62b2f19df451275b169036835660268/screenshots/before-empty-download-error.png)

수정 후: 두 파일의 다운로드를 완료한 뒤 촬영한 첨부 목록입니다. 다운로드 완료와 파일 내용은 자동 검증으로 별도 확인했습니다.

![수정 후 테스트](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/202c343ca62b2f19df451275b169036835660268/screenshots/after-attachments.png)
