### PR TITLE
fix(file): 이미지 실파일 부재 시 404 응답 처리

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
@@ -123,6 +123,10 @@ public class EgovImageProcessController extends HttpServlet {
 		String streFileNm = EgovWebUtil.filePathBlackList(fvo.getStreFileNm());
 
 		File file = new File(fileStreCours, streFileNm);
+		if (!file.isFile()) {
+			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			return;
+		}
 		
 		// Try-with-resources를 이용한 자원 해제 처리 (try 구문에 선언한 리소스를 자동 반납)
 		// try에 전달할 수 있는 자원은 java.lang.AutoCloseable 인터페이스의 구현 객체로 한정

--- a/src/test/java/egovframework/com/cmm/web/EgovImageProcessControllerTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovImageProcessControllerTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -51,8 +52,7 @@ class EgovImageProcessControllerTest {
 
         byte[] encryptedFileId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
         String encodedFileId = Base64.getEncoder().encodeToString(encryptedFileId);
-        EgovFileDownloadController.ALGORITM_KEY = "test-key";
-        when(cryptoService.decrypt(eq(encryptedFileId), eq("test-key")))
+        when(cryptoService.decrypt(eq(encryptedFileId), eq(EgovFileDownloadController.ALGORITM_KEY)))
                 .thenReturn("file-id".getBytes(StandardCharsets.UTF_8));
         when(fileService.selectFileInf(any(FileVO.class))).thenReturn(fileInfo);
 
@@ -79,8 +79,7 @@ class EgovImageProcessControllerTest {
 
         byte[] encryptedFileId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
         String encodedFileId = Base64.getEncoder().encodeToString(encryptedFileId);
-        EgovFileDownloadController.ALGORITM_KEY = "test-key";
-        when(cryptoService.decrypt(eq(encryptedFileId), eq("test-key")))
+        when(cryptoService.decrypt(eq(encryptedFileId), eq(EgovFileDownloadController.ALGORITM_KEY)))
                 .thenReturn("file-id".getBytes(StandardCharsets.UTF_8));
         when(fileService.selectFileInf(any(FileVO.class))).thenReturn(null);
 
@@ -91,6 +90,47 @@ class EgovImageProcessControllerTest {
 
         // then
         assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        assertEquals(0, response.getContentAsByteArray().length);
+    }
+
+    @DisplayName("첨부 정보가 있어도 실제 이미지 파일이 없으면 404를 응답한다.")
+    @Test
+    void getImageInfReturnsNotFoundWhenPhysicalFileIsMissing() throws Exception {
+        assertPhysicalFileNotFound("missing.jpg");
+    }
+
+    @DisplayName("이미지 저장 경로가 디렉터리이면 404를 응답한다.")
+    @Test
+    void getImageInfReturnsNotFoundWhenPathIsDirectory() throws Exception {
+        Files.createDirectory(temporaryDirectory.resolve("directory.jpg"));
+
+        assertPhysicalFileNotFound("directory.jpg");
+    }
+
+    private void assertPhysicalFileNotFound(String storedFileName) throws Exception {
+        EgovFileMngService fileService = mock(EgovFileMngService.class);
+        EgovCryptoService cryptoService = mock(EgovCryptoService.class);
+        EgovImageProcessController controller = new EgovImageProcessController();
+        ReflectionTestUtils.setField(controller, "fileService", fileService);
+        ReflectionTestUtils.setField(controller, "cryptoService", cryptoService);
+
+        FileVO fileInfo = new FileVO();
+        fileInfo.setFileStreCours(temporaryDirectory.toString());
+        fileInfo.setStreFileNm(storedFileName);
+        fileInfo.setFileExtsn("JPG");
+        when(fileService.selectFileInf(any(FileVO.class))).thenReturn(fileInfo);
+
+        byte[] encryptedFileId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
+        when(cryptoService.decrypt(eq(encryptedFileId), eq(EgovFileDownloadController.ALGORITM_KEY)))
+                .thenReturn("file-id".getBytes(StandardCharsets.UTF_8));
+        Map<String, Object> parameters = Map.of(
+                "atchFileId", Base64.getEncoder().encodeToString(encryptedFileId), "fileSn", "0");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.getImageInf(null, new ModelMap(), parameters, response);
+
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        assertNull(response.getContentType());
         assertEquals(0, response.getContentAsByteArray().length);
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

첨부 정보가 있어도 실제 이미지 파일이 없거나 경로가 디렉터리이면 빈 HTTP 200 응답을 반환합니다. 이미지가 없는 상태를 명확히 구분하도록 수정합니다.

## 수정된 소스 내용 Modified source

- 일반 파일 여부를 확인하여 파일 부재 시 HTTP 404를 반환합니다.
- 파일 유실·디렉터리 테스트를 추가하고 정상 이미지의 MIME·내용 유지를 확인합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 이미지 단위 테스트 4개 통과.
- 실제 HTTP 이미지 검증 5개 통과.
- Chrome에서 갤러리 이미지 표시·원본 바이트 일치 및 실파일 제거 후 404 확인.

실제 HTTP·브라우저 검증은 이번 백엔드 개선 4건을 함께 반영한 환경에서 수행했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 후 코드에서 확인한 정상 이미지와 실파일 유실 상태입니다. HTTP 상태와 바이트는 [테스트 결과](https://github.com/wizlife/egovframe-template-simple-backend/blob/dd9537beec20a9564704de342704a6e351533d26/TEST_RESULTS.md)로 별도 확인했습니다.

<details>
<summary>검증 화면 보기</summary>

![정상 갤러리 이미지](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/gallery-image-normal.png)

![실파일 유실 후 갤러리 상세](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/gallery-image-missing.png)

</details>
