### PR TITLE
fix(schedule): 존재하지 않는 일정 상세 조회 처리

### DIFF
--- a/src/main/java/egovframework/com/cmm/ResponseCode.java
+++ b/src/main/java/egovframework/com/cmm/ResponseCode.java
@@ -4,6 +4,7 @@ public enum ResponseCode {
 
 	SUCCESS(200, "성공했습니다."),
 	AUTH_ERROR(403, "인가된 사용자가 아닙니다."),
+	NOT_FOUND(404, "요청한 정보를 찾을 수 없습니다."),
 	DELETE_ERROR(700, "삭제 중 내부 오류가 발생했습니다."),
 	SAVE_ERROR(800, "저장시 내부 오류가 발생했습니다."),
 	INPUT_CHECK_ERROR(900, "입력값 무결성 오류 입니다.");

--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
@@ -213,7 +213,7 @@ public class EgovIndvdlSchdulManageApiController {
 	 */
     @Operation(
 			summary = "일정 상세조회",
-			description = "일정 목록을 상세조회",
+			description = "일정 목록을 상세조회. 대상이 없으면 ResultVO의 resultCode 404를 반환",
 			tags = {"EgovIndvdlSchdulManageApiController"}
 	)
 	@ApiResponses(value = {
@@ -229,6 +229,13 @@ public class EgovIndvdlSchdulManageApiController {
 
 		IndvdlSchdulManageVO indvdlSchdulManageVO = new IndvdlSchdulManageVO();
 		indvdlSchdulManageVO.setSchdulId(schdulId);
+
+		IndvdlSchdulManageVO scheduleDetail = egovIndvdlSchdulManageService
+			.selectIndvdlSchdulManageDetail(indvdlSchdulManageVO);
+		if (scheduleDetail == null) {
+			return resultVoHelper.buildFromMap(resultMap, ResponseCode.NOT_FOUND);
+		}
+		resultMap.put("scheduleDetail", scheduleDetail);
 
 		//일정시작일자(시)
 		resultMap.put("schdulBgndeHH", getTimeHH());
@@ -252,10 +259,6 @@ public class EgovIndvdlSchdulManageApiController {
 		voComCode.setCodeId("COM031");
 		resultMap.put("reptitSeCode", cmmUseService.selectCmmCodeDetail(voComCode));
 
-		IndvdlSchdulManageVO scheduleDetail = egovIndvdlSchdulManageService
-			.selectIndvdlSchdulManageDetail(indvdlSchdulManageVO);
-		resultMap.put("scheduleDetail", scheduleDetail);
-		
 		// 첨부파일 확인
 		if (scheduleDetail.getAtchFileId() != null && !scheduleDetail.getAtchFileId().isEmpty()) {
 			FileVO fileVO = new FileVO();

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerDetailTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerDetailTest.java
@@ -1,0 +1,146 @@
+package egovframework.let.cop.smt.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.ResponseCode;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovFileMngUtil;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.service.ResultVO;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.com.cmm.web.EgovFileDownloadController;
+import egovframework.let.cop.smt.sim.service.EgovIndvdlSchdulManageService;
+import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+@ExtendWith(MockitoExtension.class)
+class EgovIndvdlSchdulManageApiControllerDetailTest {
+
+	private static final String SCHEDULE_ID = "SCHDUL_0000000000001";
+
+	@Mock
+	private EgovIndvdlSchdulManageService scheduleService;
+	@Mock
+	private EgovCmmUseService cmmUseService;
+	@Mock
+	private EgovFileMngService fileMngService;
+	@Mock
+	private EgovFileMngUtil fileUtil;
+	@Mock
+	private EgovCryptoService cryptoService;
+
+	private EgovIndvdlSchdulManageApiController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovIndvdlSchdulManageApiController(scheduleService, cmmUseService,
+				fileMngService, fileUtil, cryptoService, new ResultVoHelper());
+	}
+
+	@Test
+	void missingScheduleReturnsNotFoundWithoutLoadingAttachmentsOrCodes() throws Exception {
+		ResultVO result = controller.EgovIndvdlSchdulManageDetail(SCHEDULE_ID, new LoginVO());
+
+		assertNotFound(result);
+		ArgumentCaptor<IndvdlSchdulManageVO> query = ArgumentCaptor.forClass(IndvdlSchdulManageVO.class);
+		verify(scheduleService).selectIndvdlSchdulManageDetail(query.capture());
+		assertEquals(SCHEDULE_ID, query.getValue().getSchdulId());
+		verifyNoInteractions(fileMngService, fileUtil, cryptoService, cmmUseService);
+	}
+
+	@Test
+	void scheduleNoLongerReturnedAfterDeletionGetsNotFound() throws Exception {
+		IndvdlSchdulManageVO detail = newSchedule("");
+		when(scheduleService.selectIndvdlSchdulManageDetail(any())).thenReturn(detail).thenReturn(null);
+		assertEquals(200, controller.EgovIndvdlSchdulManageDetail(SCHEDULE_ID, null).getResultCode());
+
+		controller.EgovIndvdlSchdulManageDelete(SCHEDULE_ID);
+		assertNotFound(controller.EgovIndvdlSchdulManageDetail(SCHEDULE_ID, null));
+
+		ArgumentCaptor<IndvdlSchdulManageVO> deletion = ArgumentCaptor.forClass(IndvdlSchdulManageVO.class);
+		verify(scheduleService).deleteIndvdlSchdulManage(deletion.capture());
+		assertEquals(SCHEDULE_ID, deletion.getValue().getSchdulId());
+		verifyNoInteractions(fileMngService, fileUtil, cryptoService);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void existingScheduleWithoutAttachmentKeepsDetailAndUser(String attachmentId) throws Exception {
+		IndvdlSchdulManageVO detail = newSchedule(attachmentId);
+		LoginVO user = new LoginVO();
+		when(scheduleService.selectIndvdlSchdulManageDetail(any())).thenReturn(detail);
+
+		ResultVO result = controller.EgovIndvdlSchdulManageDetail(SCHEDULE_ID, user);
+
+		assertEquals(ResponseCode.SUCCESS.getCode(), result.getResultCode());
+		assertSame(detail, result.getResult("scheduleDetail"));
+		assertSame(user, result.getResult("user"));
+		assertTrue(result.getResult().keySet().containsAll(List.of("schdulIpcrCode", "schdulSe", "reptitSeCode")));
+		assertFalse(result.getResult().containsKey("resultFiles"));
+		verifyNoInteractions(fileMngService, fileUtil, cryptoService);
+	}
+
+	@Test
+	void existingScheduleReturnsAttachmentsWithEncryptedIds() throws Exception {
+		String attachmentId = "FILE_000000000000001";
+		IndvdlSchdulManageVO detail = newSchedule(attachmentId);
+		FileVO file = new FileVO();
+		file.setAtchFileId(attachmentId);
+		file.setOrignlFileNm("schedule.xlsx");
+		List<FileVO> files = List.of(file);
+		byte[] encryptedId = "encrypted-file-id".getBytes(StandardCharsets.UTF_8);
+		when(scheduleService.selectIndvdlSchdulManageDetail(any())).thenReturn(detail);
+		when(fileMngService.selectFileInfs(any())).thenReturn(files);
+		when(cryptoService.encrypt(any(byte[].class), eq(EgovFileDownloadController.ALGORITM_KEY)))
+				.thenReturn(encryptedId);
+
+		ResultVO result = controller.EgovIndvdlSchdulManageDetail(SCHEDULE_ID, null);
+
+		assertEquals(ResponseCode.SUCCESS.getCode(), result.getResultCode());
+		assertSame(detail, result.getResult("scheduleDetail"));
+		assertSame(files, result.getResult("resultFiles"));
+		assertEquals("schedule.xlsx", file.getOrignlFileNm());
+		assertEquals(Base64.getEncoder().encodeToString(encryptedId), file.getAtchFileId());
+		ArgumentCaptor<FileVO> query = ArgumentCaptor.forClass(FileVO.class);
+		verify(fileMngService).selectFileInfs(query.capture());
+		assertEquals(attachmentId, query.getValue().getAtchFileId());
+		verify(cryptoService).encrypt(eq(attachmentId.getBytes(StandardCharsets.UTF_8)),
+				eq(EgovFileDownloadController.ALGORITM_KEY));
+	}
+
+	private IndvdlSchdulManageVO newSchedule(String attachmentId) {
+		IndvdlSchdulManageVO detail = new IndvdlSchdulManageVO();
+		detail.setSchdulId(SCHEDULE_ID);
+		detail.setAtchFileId(attachmentId);
+		return detail;
+	}
+
+	private void assertNotFound(ResultVO result) {
+		assertEquals(404, result.getResultCode());
+		assertEquals("요청한 정보를 찾을 수 없습니다.", result.getResultMessage());
+		assertTrue(result.getResult().isEmpty());
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

없는 일정 ID를 조회하거나 목록을 연 뒤 삭제된 일정에 접근하면, null 조회 결과에서 첨부파일 정보를 읽다가 HTTP 500 오류가 발생합니다.

## 수정된 소스 내용 Modified source

- 일정이 없으면 후속 조회 전에 기존 ResultVO 형식으로 반환합니다(HTTP 200 / 본문 resultCode 404 / 빈 result).
- 부재·정상·첨부 유무에 대한 컨트롤러 테스트와 응답 설명을 추가합니다.

연동 React PR: [#149](https://github.com/eGovFramework/egovframe-template-simple-react/pull/149)

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 일정 관련 단위 테스트 8개 통과.
- 실제 HTTP·HSQL 통합 검증 12개 통과: 등록·수정·삭제 후 조회, 첨부 다운로드, 월·일·주 목록.
- 연동 React의 관리자 상세·수정 및 오늘·금주 행사에서 부재 안내 후 목록 복귀 확인.

실제 HTTP·브라우저 검증은 이번 백엔드 개선 4건을 함께 반영한 환경에서 수행했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

정상 상세와 삭제된 일정의 수정 화면에서 안내를 확인한 뒤 돌아온 목록입니다. 부재 응답과 안내창은 [테스트 결과](https://github.com/wizlife/egovframe-template-simple-backend/blob/dd9537beec20a9564704de342704a6e351533d26/TEST_RESULTS.md)로 별도 검증했습니다.

<details>
<summary>검증 화면 보기</summary>

![정상 일정 상세와 첨부](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/normal-schedule-detail.png)

![부재 안내 후 월·일정구분을 유지한 목록](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/schedule-admin-return.png)

</details>
