### PR TITLE
fix(bbs): 회원 삭제 후 작성자 검색 누락 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -159,7 +159,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>				
 					
 			ORDER BY a.SORT_ORDR DESC, NTT_NO ASC
@@ -188,7 +188,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>			
 	</select>	
  

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
@@ -159,7 +159,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>				
 					
 			ORDER BY a.SORT_ORDR DESC, NTT_NO ASC
@@ -188,7 +188,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>		
 	</select>	
  

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
@@ -158,7 +158,7 @@
 					a.NTT_CN LIKE  '%' || #{searchWrd} || '%' 		
 			</if>
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					IFNULL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>
 					
 			ORDER BY a.SORT_ORDR DESC, NTT_NO ASC
@@ -187,7 +187,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					IFNULL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>			
 	</select>	
  

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
@@ -158,7 +158,7 @@
 					a.NTT_CN LIKE CONCAT ('%', #{searchWrd},'%') 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE CONCAT ('%', #{searchWrd},'%') 		
+					IFNULL(b.USER_NM, a.NTCR_NM) LIKE CONCAT ('%', #{searchWrd},'%')
 			</if>				
 					
 			ORDER BY a.SORT_ORDR DESC, NTT_NO ASC
@@ -187,7 +187,7 @@
 					a.NTT_CN LIKE CONCAT ('%', #{searchWrd},'%') 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE CONCAT ('%', #{searchWrd},'%') 		
+					IFNULL(b.USER_NM, a.NTCR_NM) LIKE CONCAT ('%', #{searchWrd},'%')
 			</if>			
 	</select>	
  

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
@@ -159,7 +159,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>				
 					
 			ORDER BY a.SORT_ORDR DESC, NTT_NO ASC
@@ -188,7 +188,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>		
 	</select>	
  

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
@@ -159,7 +159,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>				
 					
 			ORDER BY a.SORT_ORDR DESC, NTT_NO ASC
@@ -188,7 +188,7 @@
 					a.NTT_CN LIKE '%' || #{searchWrd} || '%' 		
 			</if>	
 			<if test="searchCnd == 2">AND
-					b.USER_NM LIKE '%' || #{searchWrd} || '%' 		
+					NVL(b.USER_NM, a.NTCR_NM) LIKE '%' || #{searchWrd} || '%'
 			</if>			
 	</select>	
  

--- a/src/test/java/egovframework/test/EgovBoardAuthorSearchMapperTest.java
+++ b/src/test/java/egovframework/test/EgovBoardAuthorSearchMapperTest.java
@@ -1,0 +1,133 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.InputStream;
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import egovframework.let.cop.bbs.domain.model.BoardVO;
+
+/** DB에 연결하지 않고 실제 매퍼의 검색 조건 생성과 파라미터 바인딩을 검증한다. */
+@DisplayName("게시글 작성자 검색 매퍼")
+class EgovBoardAuthorSearchMapperTest {
+
+	private static final List<String> DB_TYPES = List.of("hsql", "mysql", "oracle", "tibero", "altibase", "cubrid");
+	private static final List<String> STATEMENTS = List.of("selectBoardArticleList", "selectBoardArticleListCnt");
+	private static final String SEARCH_WORD = "표시작성자' OR 1=1 --";
+
+	@ParameterizedTest(name = "{0}: {1}")
+	@MethodSource("mapperStatements")
+	@DisplayName("작성자 검색은 현재 회원명을 우선하고 없으면 글에 저장된 이름을 사용한다")
+	void authorSearchUsesDisplayedName(String dbType, String statementId) throws Exception {
+		MappedStatement statement = mappedStatement(dbType, statementId);
+		BoardVO board = search("2");
+		BoundSql boundSql = statement.getBoundSql(board);
+		String sql = normalize(boundSql.getSql());
+		String nameExpression = (List.of("hsql", "mysql").contains(dbType) ? "IFNULL" : "NVL")
+				+ "(B.USER_NM, A.NTCR_NM)";
+
+		assertTrue(sql.contains("AND " + nameExpression + " LIKE "), sql);
+		assertEquals(1, occurrences(sql, " LIKE "), sql);
+		if (statementId.equals("selectBoardArticleList")) {
+			assertTrue(sql.contains(nameExpression + " AS FRST_REGISTER_NM"), sql);
+		}
+		assertFalse(sql.contains(" OR "), "과거 작성자명을 별도의 OR 조건으로 검색하면 안 된다");
+		assertBoundSearchWord(statement, board, boundSql);
+	}
+
+	@ParameterizedTest(name = "{0}: {1}, searchCnd={2}")
+	@MethodSource("titleAndBodySearches")
+	@DisplayName("제목과 내용 검색에는 해당 검색 조건만 적용한다")
+	void titleAndBodySearchKeepTheirOwnCondition(String dbType, String statementId, String searchCnd,
+			String column) throws Exception {
+		MappedStatement statement = mappedStatement(dbType, statementId);
+		BoardVO board = search(searchCnd);
+		BoundSql boundSql = statement.getBoundSql(board);
+		String sql = normalize(boundSql.getSql());
+
+		assertTrue(sql.contains("AND " + column + " LIKE "), sql);
+		assertEquals(1, occurrences(sql, " LIKE "), sql);
+		assertBoundSearchWord(statement, board, boundSql);
+	}
+
+	@ParameterizedTest(name = "{0}: {1}")
+	@MethodSource("mapperStatements")
+	@DisplayName("검색 조건을 지정하지 않으면 검색어 조건과 바인딩을 추가하지 않는다")
+	void noSearchConditionDoesNotAddSearchPredicate(String dbType, String statementId) throws Exception {
+		BoundSql boundSql = mappedStatement(dbType, statementId).getBoundSql(search(null));
+		String sql = normalize(boundSql.getSql());
+
+		assertFalse(sql.contains(" LIKE "), sql);
+		assertFalse(parameterProperties(boundSql).contains("searchWrd"));
+		assertTrue(sql.contains("A.USE_AT = 'Y'"), sql);
+		assertTrue(sql.contains("A.BBS_ID = ?"), sql);
+	}
+
+	private static Stream<Arguments> mapperStatements() {
+		return DB_TYPES.stream().flatMap(dbType -> STATEMENTS.stream()
+				.map(statement -> Arguments.of(dbType, statement)));
+	}
+
+	private static Stream<Arguments> titleAndBodySearches() {
+		return DB_TYPES.stream().flatMap(dbType -> STATEMENTS.stream().flatMap(statement -> Stream.of(
+				Arguments.of(dbType, statement, "0", "A.NTT_SJ"),
+				Arguments.of(dbType, statement, "1", "A.NTT_CN"))));
+	}
+
+	private static MappedStatement mappedStatement(String dbType, String statementId) throws Exception {
+		String resource = "egovframework/mapper/let/cop/bbs/EgovBoard_SQL_" + dbType + ".xml";
+		Configuration configuration = new Configuration();
+		try (InputStream input = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(input, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration.getMappedStatement("BBSManageDAO." + statementId);
+	}
+
+	private static BoardVO search(String condition) {
+		BoardVO board = new BoardVO();
+		board.setBbsId("BBSMSTR_AAAAAAAAAAAA");
+		board.setSearchCnd(condition);
+		board.setSearchWrd(SEARCH_WORD);
+		return board;
+	}
+
+	private static void assertBoundSearchWord(MappedStatement statement, BoardVO board, BoundSql boundSql)
+			throws Exception {
+		List<String> properties = parameterProperties(boundSql);
+		assertEquals(1, properties.stream().filter("searchWrd"::equals).count());
+		assertFalse(boundSql.getSql().contains(SEARCH_WORD));
+		PreparedStatement preparedStatement = mock(PreparedStatement.class);
+		statement.getConfiguration().newParameterHandler(statement, board, boundSql).setParameters(preparedStatement);
+		verify(preparedStatement).setString(properties.indexOf("searchWrd") + 1, SEARCH_WORD);
+	}
+
+	private static List<String> parameterProperties(BoundSql boundSql) {
+		return boundSql.getParameterMappings().stream().map(ParameterMapping::getProperty).toList();
+	}
+
+	private static String normalize(String sql) {
+		return sql.replaceAll("\\s+", " ").trim().toUpperCase(Locale.ROOT);
+	}
+
+	private static int occurrences(String text, String token) {
+		return (text.length() - text.replace(token, "").length()) / token.length();
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

회원 정보가 삭제된 게시글은 저장된 작성자명을 목록에 표시하지만, 작성자 검색은 회원명만 조회해 같은 이름으로 검색해도 누락됩니다.

## 수정된 소스 내용 Modified source

- 6종 DB의 목록·총개수 검색에 기존 표시명 기준을 적용해, 현재 회원명을 우선하고 없으면 게시글에 저장된 이름을 사용합니다.
- 실제 매퍼의 검색 조건 생성과 검색어 바인딩을 검증하는 테스트를 추가합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 매퍼 자동 테스트 50개 통과: 작성자·제목·내용 검색, 검색 조건 미지정, 파라미터 바인딩.
- HSQL 서비스·DAO 통합 검증 19개 통과: 회원 삭제 후 검색, 현재 이름 우선, 목록·총개수·페이징.

통합 검증은 이 PR을 포함한 백엔드 변경 4건을 함께 반영한 환경에서 수행했습니다. 실제 DB 실행은 HSQL로 확인했으며, 나머지 5종 DB는 SQL 생성·바인딩까지 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 검증으로 확인하여 [테스트 결과 기록](https://github.com/wizlife/egovframe-template-simple-backend/blob/dd9537beec20a9564704de342704a6e351533d26/TEST_RESULTS.md)을 첨부합니다.
