### PR TITLE
fix(file): 다중 첨부 저장 전 전체 파일 검증

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -105,6 +105,9 @@ public class EgovFileMngUtil {
 	FileVO fvo;
 	long maxFileSize = propertyService.getLong("Globals.posblAtchFileSize");
 
+	// 뒤의 파일이 검증에 실패해도 앞의 파일이 저장되지 않도록 먼저 모두 검증한다.
+	validateFiles(files, maxFileSize);
+
 	while (itr.hasNext()) {
 	    Entry<String, MultipartFile> entry = itr.next();
 
@@ -128,22 +131,9 @@ public class EgovFileMngUtil {
 	    }
 	    ////------------------------------------
 	    
-		int index = orginFileName.lastIndexOf(".");
-	    if (index < 0) {
-	        throw new EgovBizException("확장자가 없는 파일은 업로드할 수 없습니다.");
-	    }
+	    int index = orginFileName.lastIndexOf(".");
 	    String fileExt = orginFileName.substring(index + 1).toLowerCase();
-
-	    // 확장자 화이트리스트 검증
-	    if (!allowedExtensions().contains(fileExt)) {
-	        throw new EgovBizException("허용되지 않는 파일 확장자입니다: " + fileExt);
-	    }
-
-	    // 파일 크기 검증
 	    long _size = file.getSize();
-	    if (_size > maxFileSize) {
-			throw new EgovBizException("파일 크기가 허용 한도(" + maxFileSize + "바이트)를 초과했습니다.");
-	    }
 
 	    // 파일명 정규화 (경로 탈출·제어문자 제거)
 	    String safeOriginFileName = orginFileName.replaceAll("[\\p{Cntrl}\\\\/:*?\"<>|]", "_");
@@ -179,6 +169,27 @@ public class EgovFileMngUtil {
 	}
 
 	return result;
+    }
+
+    private void validateFiles(Map<String, MultipartFile> files, long maxFileSize) throws EgovBizException {
+        for (MultipartFile file : files.values()) {
+            String originalFileName = file.getOriginalFilename();
+            if (originalFileName == null || originalFileName.isEmpty()) {
+                continue;
+            }
+
+            int index = originalFileName.lastIndexOf(".");
+            if (index < 0) {
+                throw new EgovBizException("확장자가 없는 파일은 업로드할 수 없습니다.");
+            }
+            String fileExt = originalFileName.substring(index + 1).toLowerCase();
+            if (!allowedExtensions().contains(fileExt)) {
+                throw new EgovBizException("허용되지 않는 파일 확장자입니다: " + fileExt);
+            }
+            if (file.getSize() > maxFileSize) {
+                throw new EgovBizException("파일 크기가 허용 한도(" + maxFileSize + "바이트)를 초과했습니다.");
+            }
+        }
     }
 
 }

--- a/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
@@ -7,13 +7,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -136,5 +139,142 @@ class EgovFileMngUtilTest {
 
         // then
         assertTrue(result.isEmpty());
+    }
+
+    @DisplayName("정상 파일 다음에 크기 제한을 초과한 파일이 있으면 아무 파일도 저장하지 않는다.")
+    @Test
+    void rejectsOversizedLastFileBeforeSaving(@TempDir Path tempDir) throws Exception {
+        assertRejectedWithoutNewFiles(tempDir, upload("first.png", new byte[] {1, 2}),
+                upload("large.png", new byte[5]));
+    }
+
+    @DisplayName("첫 파일이 크기 제한을 초과하면 뒤의 정상 파일도 저장하지 않는다.")
+    @Test
+    void rejectsOversizedFirstFileBeforeSaving(@TempDir Path tempDir) throws Exception {
+        assertRejectedWithoutNewFiles(tempDir, upload("large.png", new byte[5]),
+                upload("second.png", new byte[] {1, 2}));
+    }
+
+    @DisplayName("정상 파일 다음에 금지 확장자 파일이 있으면 아무 파일도 저장하지 않는다.")
+    @Test
+    void rejectsDisallowedLastFileBeforeSaving(@TempDir Path tempDir) throws Exception {
+        assertRejectedWithoutNewFiles(tempDir, upload("first.png", new byte[] {1, 2}),
+                upload("second.exe", new byte[] {3}));
+    }
+
+    @DisplayName("정상 파일 다음에 확장자 없는 파일이 있으면 아무 파일도 저장하지 않는다.")
+    @Test
+    void rejectsExtensionlessLastFileBeforeSaving(@TempDir Path tempDir) throws Exception {
+        assertRejectedWithoutNewFiles(tempDir, upload("first.png", new byte[] {1, 2}),
+                upload("second", new byte[] {3}));
+    }
+
+    @DisplayName("모든 파일이 정상이면 원본 내용, 파일명 정규화, 순서와 파일 번호를 유지한다.")
+    @Test
+    void savesValidFilesInOrder(@TempDir Path tempDir) throws Exception {
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+        when(idgenService.getNextStringId()).thenReturn("ATCH0002");
+        byte[] firstContent = {1, 2, 3};
+        byte[] secondContent = {4, 5};
+
+        List<FileVO> result = egovFileMngUtil.parseFileInf(uploads(
+                upload("photo:one.PNG", firstContent), upload("second.xlsx", secondContent)), "KEY", 7, "", "");
+
+        assertEquals(2, result.size());
+        FileVO first = result.get(0);
+        FileVO second = result.get(1);
+        assertEquals("photo_one.PNG", first.getOrignlFileNm());
+        assertEquals("second.xlsx", second.getOrignlFileNm());
+        assertEquals("png", first.getFileExtsn());
+        assertEquals("xlsx", second.getFileExtsn());
+        assertEquals("3", first.getFileMg());
+        assertEquals("2", second.getFileMg());
+        assertEquals("7", first.getFileSn());
+        assertEquals("8", second.getFileSn());
+        assertEquals("ATCH0002", first.getAtchFileId());
+        assertEquals("ATCH0002", second.getAtchFileId());
+        assertEquals(tempDir.toString(), first.getFileStreCours());
+        assertEquals(tempDir.toString(), second.getFileStreCours());
+        assertTrue(first.getStreFileNm().startsWith("KEY"));
+        assertTrue(second.getStreFileNm().startsWith("KEY"));
+        assertNotEquals(first.getStreFileNm(), second.getStreFileNm());
+        assertArrayEquals(firstContent, Files.readAllBytes(tempDir.resolve(first.getStreFileNm())));
+        assertArrayEquals(secondContent, Files.readAllBytes(tempDir.resolve(second.getStreFileNm())));
+        assertFileCount(tempDir, 2);
+        verify(idgenService).getNextStringId();
+    }
+
+    @DisplayName("파일명 없는 입력은 건너뛰고 이름이 있는 빈 파일은 저장한다.")
+    @Test
+    void skipsUnnamedInputsButSavesNamedEmptyFile(@TempDir Path tempDir) throws Exception {
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+        MultipartFile nullNameFile = mock(MultipartFile.class);
+        when(nullNameFile.getOriginalFilename()).thenReturn(null);
+
+        List<FileVO> result = egovFileMngUtil.parseFileInf(uploads(
+                upload("", new byte[0]), nullNameFile, upload("empty.xlsx", new byte[0])),
+                "KEY", 3, " ATCH 0003 ", "");
+
+        assertEquals(1, result.size());
+        FileVO file = result.get(0);
+        assertEquals("empty.xlsx", file.getOrignlFileNm());
+        assertEquals("xlsx", file.getFileExtsn());
+        assertEquals("0", file.getFileMg());
+        assertEquals("3", file.getFileSn());
+        assertEquals("ATCH0003", file.getAtchFileId());
+        Path savedFile = tempDir.resolve(file.getStreFileNm());
+        assertTrue(Files.isRegularFile(savedFile));
+        assertEquals(0, Files.size(savedFile));
+        assertFileCount(tempDir, 1);
+        verify(idgenService, times(0)).getNextStringId();
+        verify(nullNameFile, times(0)).transferTo(any(java.io.File.class));
+    }
+
+    @DisplayName("허용 한도와 크기가 같은 파일은 저장한다.")
+    @Test
+    void savesFileAtSizeLimit(@TempDir Path tempDir) throws Exception {
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+        when(propertyService.getLong("Globals.posblAtchFileSize")).thenReturn(4L);
+        byte[] content = {1, 2, 3, 4};
+
+        List<FileVO> result = egovFileMngUtil.parseFileInf(
+                uploads(upload("limit.png", content)), "KEY", 0, "ATCH0004", "");
+
+        assertEquals(1, result.size());
+        assertEquals("4", result.get(0).getFileMg());
+        assertArrayEquals(content, Files.readAllBytes(tempDir.resolve(result.get(0).getStreFileNm())));
+        assertFileCount(tempDir, 1);
+    }
+
+    private void assertRejectedWithoutNewFiles(Path tempDir, MultipartFile... files) throws Exception {
+        when(propertyService.getString("Globals.fileStorePath")).thenReturn(tempDir.toString());
+        when(propertyService.getLong("Globals.posblAtchFileSize")).thenReturn(4L);
+        Path existingFile = tempDir.resolve("existing.png");
+        byte[] existingContent = {9, 8, 7};
+        Files.write(existingFile, existingContent);
+
+        assertThrows(EgovBizException.class,
+                () -> egovFileMngUtil.parseFileInf(uploads(files), "KEY", 1, "ATCH0001", ""));
+
+        assertArrayEquals(existingContent, Files.readAllBytes(existingFile));
+        assertFileCount(tempDir, 1);
+    }
+
+    private MockMultipartFile upload(String originalName, byte[] content) {
+        return new MockMultipartFile("file", originalName, "application/octet-stream", content);
+    }
+
+    private Map<String, MultipartFile> uploads(MultipartFile... files) {
+        Map<String, MultipartFile> result = new LinkedHashMap<>();
+        for (int index = 0; index < files.length; index++) {
+            result.put("file_" + index, files[index]);
+        }
+        return result;
+    }
+
+    private void assertFileCount(Path directory, long expectedCount) throws Exception {
+        try (Stream<Path> savedFiles = Files.list(directory)) {
+            assertEquals(expectedCount, savedFiles.count());
+        }
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

여러 첨부파일을 하나씩 검증하고 저장하여, 뒤쪽 파일이 확장자·크기 제한으로 거부되면 앞서 저장한 파일이 디스크에 남습니다.

## 수정된 소스 내용 Modified source

- 이름이 있는 모든 첨부의 확장자·크기를 먼저 검증한 뒤 파일 저장을 시작합니다.
- 검증 실패 시 새 파일이 남지 않는지와 정상 저장·순서·크기 경계·빈 파일 처리 테스트를 추가합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 파일 업로드 관련 단위 테스트 21개 통과.
- 실제 HTTP·HSQL 업로드 통합 검증 8개 통과: 거부 시 새 파일·DB 행 미생성 및 기존 파일 보존, 정상 다중 첨부, 5MiB 경계, 이름 있는 0바이트 파일 저장.

통합 검증은 이 PR을 포함한 백엔드 변경 4건을 함께 반영한 환경에서 수행했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 검증으로 확인하여 [테스트 결과 기록](https://github.com/wizlife/egovframe-template-simple-backend/blob/dd9537beec20a9564704de342704a6e351533d26/TEST_RESULTS.md)을 첨부합니다.
