### PR TITLE
fix: EgovStringUtil Javadoc 오타 수정 (더할분자열 → 더할문자열)

### DIFF
--- a/src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java
@@ -73,7 +73,7 @@ public class EgovStringUtil {
 	 * @param source 원본 문자열 배열
 	 * @param output 더할문자열
 	 * @param slength 지정길이
-	 * @return 지정길이로 잘라서 더할분자열 합친 문자열
+	 * @return 지정길이로 잘라서 더할문자열 합친 문자열
 	 */
 	public static String cutString(String source, String output, int slength) {
 		String returnVal = null;
@@ -91,7 +91,7 @@ public class EgovStringUtil {
 	 * 문자열이 지정한 길이를 초과했을때 해당 문자열을 삭제하는 메서드
 	 * @param source 원본 문자열 배열
 	 * @param slength 지정길이
-	 * @return 지정길이로 잘라서 더할분자열 합친 문자열
+	 * @return 지정길이로 잘라서 더할문자열 합친 문자열
 	 */
 	public static String cutString(String source, int slength) {
 		String result = null;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

- `EgovStringUtil.java`의 `cutString` 메서드 2개의 `@return` Javadoc 설명에서 오타('더할**분**자열' → '더할**문**자열')를 수정합니다.
- 변경 파일
  - `src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java` (76, 94줄)

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
