### PR TITLE
fix(bbs): 게시판 마스터 수정이 경로변수를 쓰지 않아 본문이 대상을 정하던 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiController.java
+++ b/src/main/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiController.java
@@ -252,13 +252,15 @@ public class EgovBBSAttributeManageApiController {
 				        )),
 				})
 	@PutMapping(value ="/bbsMaster/{bbsId}")
-	public IntermediateResultVO<Object> updateBBSMasterInf(@Valid @RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
+	public IntermediateResultVO<Object> updateBBSMasterInf(@PathVariable("bbsId") String bbsId,
+										@Valid @RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
 										BindingResult bindingResult,
 										@Parameter(hidden = true) @AuthenticationPrincipal LoginVO loginVO
 										) throws Exception {
 
+		bbsAttributeUpdateRequestDTO.setBbsId(bbsId);
+
 		if (bindingResult.hasErrors()) {
-			String bbsId = bbsAttributeUpdateRequestDTO.getBbsId();
 			BbsFileAtchResponseDTO result = bbsAttrbService.selectBBSMasterInf(bbsId, null, BbsDetailRequestType.DETAIL);
 
 			return IntermediateResultVO.inputCheckError(result);

--- a/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiControllerAttachmentSizeTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiControllerAttachmentSizeTest.java
@@ -74,7 +74,7 @@ class EgovBBSAttributeManageApiControllerAttachmentSizeTest {
             request.setBbsTyCode("BBST01");
             request.setBbsAttrbCode("BBSA02");
 
-            IntermediateResultVO<?> result = controller.updateBBSMasterInf(request,
+            IntermediateResultVO<?> result = controller.updateBBSMasterInf("BBSMSTR_000000000001", request,
                     new BeanPropertyBindingResult(request, "request"), loginVO);
 
             ArgumentCaptor<BbsAttributeUpdateRequestDTO> captor =

--- a/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiControllerPathVariableTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/controller/EgovBBSAttributeManageApiControllerPathVariableTest.java
@@ -1,0 +1,79 @@
+package egovframework.let.cop.bbs.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.springframework.validation.BeanPropertyBindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.config.EgovConfigAppProperties;
+import egovframework.let.cop.bbs.dto.request.BbsAttributeUpdateRequestDTO;
+import egovframework.let.cop.bbs.service.EgovBBSAttributeManageService;
+
+/**
+ * PUT /bbsMaster/{bbsId} 가 경로변수를 수정 대상으로 쓰는지 검증한다.
+ *
+ * <p>같은 컨트롤러의 조회·삭제는 경로변수를 읽는데 이 핸들러만 매핑에 {bbsId} 를 선언해 놓고
+ * 본문 DTO 의 값으로 갱신했다. URL 과 본문이 다른 게시판을 가리키면 본문 쪽이 수정된다.
+ */
+class EgovBBSAttributeManageApiControllerPathVariableTest {
+
+    private static final String PATH_BBS_ID = "BBSMSTR_000000000001";
+    private static final String BODY_BBS_ID = "BBSMSTR_999999999999";
+
+    private EgovBBSAttributeManageService bbsAttrbService;
+    private LoginVO loginVO;
+
+    @BeforeEach
+    void setUp() {
+        bbsAttrbService = mock(EgovBBSAttributeManageService.class);
+        loginVO = new LoginVO();
+        loginVO.setUniqId("USRCNFRM_00000000001");
+    }
+
+    @Test
+    @DisplayName("URL 과 본문이 다른 게시판을 가리키면 URL 쪽이 수정 대상이 된다")
+    void updateUsesPathVariableAsTarget() throws Exception {
+        try (AnnotationConfigApplicationContext context = createPropertiesContext()) {
+            EgovBBSAttributeManageApiController controller = createController(context);
+
+            BbsAttributeUpdateRequestDTO request = new BbsAttributeUpdateRequestDTO();
+            request.setBbsId(BODY_BBS_ID);
+            request.setBbsNm("테스트 게시판");
+            request.setBbsIntrcn("경로변수 바인딩 검증");
+            request.setBbsTyCode("BBST01");
+            request.setBbsAttrbCode("BBSA02");
+
+            controller.updateBBSMasterInf(PATH_BBS_ID, request,
+                    new BeanPropertyBindingResult(request, "request"), loginVO);
+
+            ArgumentCaptor<BbsAttributeUpdateRequestDTO> captor =
+                    ArgumentCaptor.forClass(BbsAttributeUpdateRequestDTO.class);
+            verify(bbsAttrbService).updateBBSMasterInf(captor.capture());
+
+            assertEquals(PATH_BBS_ID, captor.getValue().getBbsId());
+        }
+    }
+
+    private AnnotationConfigApplicationContext createPropertiesContext() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        TestPropertySourceUtils.addPropertiesFilesToEnvironment(context, "classpath:application.properties");
+        context.register(EgovConfigAppProperties.class);
+        context.refresh();
+        return context;
+    }
+
+    private EgovBBSAttributeManageApiController createController(AnnotationConfigApplicationContext context) {
+        return new EgovBBSAttributeManageApiController(bbsAttrbService, mock(EgovCmmUseService.class),
+                context.getBean(EgovPropertyService.class));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`PUT /bbsMaster/{bbsId}` 는 매핑에 경로변수를 선언해 두고 파라미터로 받지 않습니다.

```java
	@PutMapping(value ="/bbsMaster/{bbsId}")
	public IntermediateResultVO<Object> updateBBSMasterInf(@Valid @RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
										BindingResult bindingResult,
										@Parameter(hidden = true) @AuthenticationPrincipal LoginVO loginVO
										) throws Exception {
```

수정 대상은 본문 DTO 의 `bbsId` 로만 정해집니다. `BbsAttributeUpdateRequestDTO.toBoardMaster()` 가 그 값을 담고 매퍼가 그 값으로 대상 행을 고릅니다(`EgovBBSMaster_SQL_mysql.xml:161` `WHERE BBS_ID = #{bbsId}`, `updateBBSMasterInf` 블록은 150 행부터입니다). 방언 여섯 벌이 모두 같습니다. URL 과 본문이 다른 게시판을 가리키면 본문 쪽이 수정됩니다.

같은 컨트롤러의 다른 핸들러는 경로변수를 읽습니다.

```java
			@PathVariable("bbsId") String bbsId)
```

### 수정

경로변수를 받아 DTO 에 채웁니다.

```diff
 	@PutMapping(value ="/bbsMaster/{bbsId}")
-	public IntermediateResultVO<Object> updateBBSMasterInf(@Valid @RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
+	public IntermediateResultVO<Object> updateBBSMasterInf(@PathVariable("bbsId") String bbsId,
+										@Valid @RequestBody BbsAttributeUpdateRequestDTO bbsAttributeUpdateRequestDTO,
 										BindingResult bindingResult,
 										@Parameter(hidden = true) @AuthenticationPrincipal LoginVO loginVO
 										) throws Exception {
+
+		bbsAttributeUpdateRequestDTO.setBbsId(bbsId);
```

검증 실패 분기가 본문에서 `bbsId` 를 다시 꺼내던 지역변수는 필요 없어져 지웠습니다.

`EgovBBSAttributeManageApiControllerAttachmentSizeTest:77` 이 이 핸들러를 직접 호출하므로 인자를 하나 더해 맞췄습니다. 그 테스트는 그대로 통과합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovBBSAttributeManageApiControllerPathVariableTest` 를 넣었습니다. URL 과 본문이 다른 게시판을 가리키게 하고 서비스에 넘어간 DTO 가 URL 쪽을 대상으로 삼는지 봅니다.

수정 전(경로변수를 DTO 에 채우는 줄만 주석 처리)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.526 s <<< FAILURE! -- in egovframework.let.cop.bbs.controller.EgovBBSAttributeManageApiControllerPathVariableTest
org.opentest4j.AssertionFailedError: expected: <BBSMSTR_000000000001> but was: <BBSMSTR_999999999999>
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.539 s -- in egovframework.let.cop.bbs.controller.EgovBBSAttributeManageApiControllerPathVariableTest
```

전체는 `Tests run: 188, Failures: 0, Errors: 1` 입니다. 남은 오류 1건은 `TestEgovLoginApiControllerSelenium` 이고 브라우저가 없어 나는 기존 실패입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

브라우저와 무관한 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면에는 변화가 없습니다.
