### PR TITLE
fix(sim): 일간·주간 조회가 year 만 받으면 500 으로 죽던 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
@@ -429,7 +429,7 @@ public class EgovIndvdlSchdulManageApiController {
 		int iNowMonth = calNow.get(Calendar.MONTH);
 		int iNowDay = calNow.get(Calendar.DATE);
 
-		if (strYear != null) {
+		if (strYear != null && strMonth != null && strDay != null) {
 			iNowYear = Integer.parseInt(strYear);
 			iNowMonth = Integer.parseInt(strMonth);
 			iNowDay = Integer.parseInt(strDay);
@@ -502,7 +502,7 @@ public class EgovIndvdlSchdulManageApiController {
 		int iNowMonth = calNow.get(Calendar.MONTH);
 		int iNowDate = calNow.get(Calendar.DATE);
 
-		if (strYear != null) {
+		if (strYear != null && strMonth != null && strDate != null) {
 			iNowYear = Integer.parseInt(strYear);
 			iNowMonth = Integer.parseInt(strMonth);
 			iNowDate = Integer.parseInt(strDate);

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerPartialDateParamTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerPartialDateParamTest.java
@@ -1,0 +1,112 @@
+package egovframework.let.cop.smt.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovFileMngUtil;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.cop.smt.sim.service.EgovIndvdlSchdulManageService;
+import egovframework.let.cop.smt.sim.service.ScheduleSearchVO;
+
+/**
+ * @Class             EgovIndvdlSchdulManageApiControllerPartialDateParamTest.java
+ * @Description     year 만 주고 month·date 를 빼면 파싱 게이트가 통과해 NumberFormatException 이
+ *                        나던 일간·주간 조회의 회귀 테스트. 같은 컨트롤러의 월간 조회는 파싱하는 필드를
+ *                        전부 null 검사해 오늘 기준으로 폴백한다.
+ * @author            wantaek
+ * @since             2026. 9. 9.
+ *
+ * <pre>
+ * <개정이력(Modification Information)>
+ * 개정일자                 개정자                  개정내용
+ * ------------------ ----------- --------------------------
+ * 2026. 9. 9.           wantaek           최초생성
+ *
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovIndvdlSchdulManageApiControllerPartialDateParamTest {
+
+	@Mock
+	private EgovIndvdlSchdulManageService egovIndvdlSchdulManageService;
+
+	@Mock
+	private EgovCmmUseService cmmUseService;
+
+	@Mock
+	private EgovFileMngService fileMngService;
+
+	@Mock
+	private EgovFileMngUtil fileUtil;
+
+	@Mock
+	private EgovCryptoService cryptoService;
+
+	private EgovIndvdlSchdulManageApiController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovIndvdlSchdulManageApiController(
+				egovIndvdlSchdulManageService, cmmUseService, fileMngService, fileUtil, cryptoService, new ResultVoHelper());
+	}
+
+	/** 오늘 기준으로 폴백했을 때 나와야 하는 yyyyMMdd */
+	private static String today() {
+		return new SimpleDateFormat("yyyyMMdd").format(Calendar.getInstance().getTime());
+	}
+
+	@Test
+	@DisplayName("일간 조회에 year 만 주면 month·date 를 오늘로 채워 조회한다")
+	void dailyList_withYearOnly_fallsBackToToday() throws Exception {
+		when(cmmUseService.selectCmmCodeDetail(any())).thenReturn(Collections.emptyList());
+		when(egovIndvdlSchdulManageService.selectIndvdlSchdulManageRetrieve(any())).thenReturn(Collections.emptyList());
+
+		ScheduleSearchVO searchVO = new ScheduleSearchVO();
+		searchVO.setYear("2026");
+
+		assertDoesNotThrow(() -> controller.EgovIndvdlSchdulManageDailyList(searchVO));
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+		verify(egovIndvdlSchdulManageService).selectIndvdlSchdulManageRetrieve(captor.capture());
+
+		assertEquals(today(), captor.getValue().get("searchDay"));
+	}
+
+	@Test
+	@DisplayName("주간 조회에 year 만 주면 month·date 를 오늘로 채워 조회한다")
+	void weekList_withYearOnly_fallsBackToToday() throws Exception {
+		when(cmmUseService.selectCmmCodeDetail(any())).thenReturn(Collections.emptyList());
+		when(egovIndvdlSchdulManageService.selectIndvdlSchdulManageRetrieve(any())).thenReturn(Collections.emptyList());
+
+		ScheduleSearchVO searchVO = new ScheduleSearchVO();
+		searchVO.setYear("2026");
+
+		assertDoesNotThrow(() -> controller.EgovIndvdlSchdulManageWeekList(searchVO));
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+		verify(egovIndvdlSchdulManageService).selectIndvdlSchdulManageRetrieve(captor.capture());
+
+		assertEquals(today(), captor.getValue().get("schdulBgnde"));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

일간·주간 조회는 `year`·`month`·`date` 셋을 파싱하면서 `year` 하나만 `null` 검사합니다.

```java
		if (strYear != null) {
			iNowYear = Integer.parseInt(strYear);
			iNowMonth = Integer.parseInt(strMonth);
			iNowDay = Integer.parseInt(strDay);
		}
```

`GET /schedule/daily?year=2026` 처럼 `year` 만 주면 나머지 둘이 `null` 인 채로 `Integer.parseInt` 에 들어가 `NumberFormatException` 이 나고 500 이 나갑니다. 주간도 같은 모양입니다.

같은 컨트롤러의 월간 조회는 파싱하는 필드를 전부 검사하고 오늘로 폴백합니다.

```java
		if (sYear == null || sMonth == null) {
			sSearchDate += Integer.toString(iYear);
			sSearchDate += Integer.toString(iMonth + 1).length() == 1 ? "0" + Integer.toString(iMonth + 1)
				: Integer.toString(iMonth + 1);
		} else {
```

`ScheduleSearchVO` 는 세 필드 다 기본값 없는 `String` 이고 필수 표기도 없습니다.

### 수정

게이트를 월간 쪽과 같은 형태로 맞춥니다.

```diff
-		if (strYear != null) {
+		if (strYear != null && strMonth != null && strDay != null) {
```

```diff
-		if (strYear != null) {
+		if (strYear != null && strMonth != null && strDate != null) {
```

셋 다 주면 전과 같이 그 값으로 조회하고 하나라도 빠지면 오늘 기준으로 폴백합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovIndvdlSchdulManageApiControllerPartialDateParamTest` 를 넣었습니다. 기존 `WeekListTest` 와 같은 순수 Mockito 구성이라 스프링 컨텍스트를 띄우지 않습니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.535 s <<< FAILURE! -- in egovframework.let.cop.smt.sim.web.EgovIndvdlSchdulManageApiControllerPartialDateParamTest
org.opentest4j.AssertionFailedError: Unexpected exception thrown: java.lang.NumberFormatException: Cannot parse null string
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.498 s -- in egovframework.let.cop.smt.sim.web.EgovIndvdlSchdulManageApiControllerPartialDateParamTest
```

전체는 같은 워크트리에서 이 수정만 토글해 대조했습니다. 수정 있음 `Tests run: 189, Failures: 0, Errors: 1`, 수정 없음 `Tests run: 189, Failures: 2, Errors: 1` 이고 늘어난 실패 2건이 위 테스트입니다. 오류 1건은 양쪽 같은 `TestEgovLoginApiControllerSelenium` 이고 브라우저가 없어 나는 기존 실패입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

브라우저와 무관한 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면에는 변화가 없습니다.
