### PR TITLE
docs(sim): 조회 월 파라미터 설명이 실제 해석과 다른 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/service/ScheduleSearchVO.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/service/ScheduleSearchVO.java
@@ -15,7 +15,7 @@ public class ScheduleSearchVO {
     @Schema(description = "조회 연도", example = "2025")
     private String year;
 
-    @Schema(description = "조회 월 (1~12)", example = "5")
+    @Schema(description = "조회 월 (0~11, 1월=0)", example = "4")
     private String month;
 
     @Schema(description = "조회 일 (1~31)", example = "7")

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerMonthBaseTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiControllerMonthBaseTest.java
@@ -1,0 +1,79 @@
+package egovframework.let.cop.smt.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovFileMngUtil;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.cop.smt.sim.service.EgovIndvdlSchdulManageService;
+import egovframework.let.cop.smt.sim.service.ScheduleSearchVO;
+
+/**
+ * ScheduleSearchVO.month 가 0-base(1월=0)로 해석된다는 계약을 고정한다.
+ *
+ * <p>@Schema 는 이 값을 1~12 로 적어 두었으나 조회 경로는 받은 값에 1 을 더해 검색월을 만든다.
+ * 문서대로 12 를 넣으면 검색월이 13 이 되어 12월 안에서 시작하고 끝나는 일정이 빠진다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovIndvdlSchdulManageApiControllerMonthBaseTest {
+
+	@Mock
+	private EgovIndvdlSchdulManageService egovIndvdlSchdulManageService;
+
+	@Mock
+	private EgovCmmUseService cmmUseService;
+
+	@Mock
+	private EgovFileMngService fileMngService;
+
+	@Mock
+	private EgovFileMngUtil fileUtil;
+
+	@Mock
+	private EgovCryptoService cryptoService;
+
+	private EgovIndvdlSchdulManageApiController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovIndvdlSchdulManageApiController(
+				egovIndvdlSchdulManageService, cmmUseService, fileMngService, fileUtil, cryptoService, new ResultVoHelper());
+	}
+
+	@DisplayName("월간 조회의 month 는 0-base 로 해석된다 (0=1월, 11=12월, 문서대로 12 를 주면 13월이 된다)")
+	@ParameterizedTest(name = "month={0} → searchMonth={1}")
+	@CsvSource({"0,202601", "4,202605", "11,202612", "12,202613"})
+	void monthListInterpretsMonthAsZeroBased(String month, String expectedSearchMonth) throws Exception {
+		when(cmmUseService.selectCmmCodeDetail(any())).thenReturn(Collections.emptyList());
+		when(egovIndvdlSchdulManageService.selectIndvdlSchdulManageRetrieve(any())).thenReturn(Collections.emptyList());
+
+		ScheduleSearchVO searchVO = new ScheduleSearchVO();
+		searchVO.setYear("2026");
+		searchVO.setMonth(month);
+
+		controller.EgovIndvdlSchdulManageMonthList(searchVO, null);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+		verify(egovIndvdlSchdulManageService).selectIndvdlSchdulManageRetrieve(captor.capture());
+
+		assertEquals(expectedSearchMonth, captor.getValue().get("searchMonth"));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

`ScheduleSearchVO.month` 의 설명이 실제 해석과 다릅니다.

```java
    @Schema(description = "조회 월 (1~12)", example = "5")
    private String month;
```

조회 경로 셋은 받은 값에 1 을 더해 검색월을 만듭니다. 월간은 `Integer.toString(iMonth + 1)`, 일간은 `DateTypeIntForString(iNowMonth + 1)`, 주간은 `int realMonth = iNowMonth + 1` 입니다. 주간 쪽에는 이유도 적혀 있습니다.

```java
		//프론트에서 넘어온 값은 1월을 0으로 간주하므로 1달 더해 줌
		int realMonth = iNowMonth + 1;
```

문서대로 `month=12` 를 넣으면 검색월이 `13` 이 됩니다. 매퍼가 문자열 범위로 거릅니다.

```xml
		 	 AND (#{searchMonth} BETWEEN SUBSTRING(DATE_FORMAT(A.SCHDUL_BEGINDE,'%Y%m%d'), 1, 6)  AND SUBSTRING(DATE_FORMAT(A.SCHDUL_ENDDE,'%Y%m%d'), 1, 6) )
```

문자열 비교라 `202613` 은 이듬해 이후까지 이어지는 일정에 걸립니다. 시작월은 상관없습니다. 12월 안에서 시작하고 끝나는 일정은 하나도 안 나옵니다. 예외가 아니라 조용히 줄어든 목록입니다.

형제 필드 `date` 는 문서와 코드가 맞습니다.

```java
    @Schema(description = "조회 일 (1~31)", example = "7")
    private String date;
```

일간 조회는 `date` 에 1 을 더하지 않습니다. 이 PR 은 `month` 설명만 고칩니다.

### 수정

설명을 실제 계약에 맞춥니다.

```diff
-    @Schema(description = "조회 월 (1~12)", example = "5")
+    @Schema(description = "조회 월 (0~11, 1월=0)", example = "4")
```

`example` 도 같은 달(5월)을 가리키도록 바꿨습니다. 코드는 건드리지 않았습니다 — 0-base 는 화면이 이미 그렇게 보내고 있어 코드를 1-base 로 돌리면 기존 클라이언트가 한 달 밀립니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovIndvdlSchdulManageApiControllerMonthBaseTest` 를 넣었습니다. 0-base 해석 자체를 고정해 나중에 코드가 바뀌면 이 설명도 같이 손대게 합니다.

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.524 s -- in egovframework.let.cop.smt.sim.web.EgovIndvdlSchdulManageApiControllerMonthBaseTest
```

`month=0` 이 `202601`, `11` 이 `202612`, 그리고 문서대로 넣은 `12` 가 `202613` 이 되는 것을 단언합니다.

전체는 `Tests run: 191, Failures: 0, Errors: 1` 입니다. 오류 1건은 `TestEgovLoginApiControllerSelenium` 이고 브라우저가 없어 나는 기존 실패입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

Swagger UI 실물 화면은 확인하지 못했습니다. 서버를 띄우지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면에는 변화가 없습니다. 바뀌는 것은 API 문서의 파라미터 설명입니다.
