### PR TITLE
build(deps): eGovFrame Boot 5.0.1로 의존성 관리를 갱신

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>egovframework</groupId>
 	<artifactId>egovframe-boot-simple-backend</artifactId>
+	<version>5.0.2</version>
 	<packaging>jar</packaging>
-	<version>5.0.0</version>
 	<name>egovframe-boot-simple-backend</name>
 	<url>http://www.egovframe.go.kr</url>
 
@@ -21,22 +21,16 @@
 	<parent>
 		<groupId>org.egovframe.boot</groupId>
 		<artifactId>egovframe-boot-starter-parent</artifactId>
-		<version>5.0.0</version>
+		<version>5.0.1</version>
 	</parent>
 
 	<properties>
 		<java.version>17</java.version>
 		<springdoc.openapi.ui.version>2.6.0</springdoc.openapi.ui.version>
 		<protobuf.java.version>3.25.5</protobuf.java.version>
-		<log4j2.version>2.25.3</log4j2.version>
-		<slf4j.version>2.0.17</slf4j.version>
-		<log4jdbc.version>1.2</log4jdbc.version>
 		<jjwt.version>0.12.6</jjwt.version>
 		<icu4j.version>77.1</icu4j.version>
-		<tomcat-embed.version>10.1.52</tomcat-embed.version>
-		<commons-beanutils.version>1.11.0</commons-beanutils.version>
-		<commons-lang3.version>3.18.0</commons-lang3.version>
-		<hikaricp.version>6.3.3</hikaricp.version>
+		<tomcat.version>10.1.59</tomcat.version>
 	</properties>
 
 	<repositories>
@@ -189,7 +183,6 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>${hikaricp.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -231,29 +224,24 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>${log4j2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>${log4j2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>log4j-over-slf4j</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 
 		<!-- log4jdbc driver -->
 		<dependency>
 			<groupId>com.googlecode.log4jdbc</groupId>
 			<artifactId>log4jdbc</artifactId>
-			<version>${log4jdbc.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -279,41 +267,34 @@
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-annotations-api</artifactId>
-			<version>${tomcat-embed.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-core</artifactId>
-			<version>${tomcat-embed.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-el</artifactId>
-			<version>${tomcat-embed.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-jasper</artifactId>
-			<version>${tomcat-embed.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-websocket</artifactId>
-			<version>${tomcat-embed.version}</version>
 		</dependency>
 
 		<!-- CVE-2025-48734: 보안취약점 보완용 직접 주입 -->
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>${commons-beanutils.version}</version>
 		</dependency>
 
 		<!-- CVE-2025-48924: 보안취약점 보완용 직접 주입 -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>${commons-lang3.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

eGovFrame Boot 부모 스타터를 5.0.1로 갱신하고 프로젝트 버전을
5.0.2로 변경합니다.

부모 BOM에서 관리하는 의존성은 개별 버전 지정을 제거하여
프로젝트의 의존성 버전 관리를 일원화합니다.

## 변경 사항

- 프로젝트 버전을 `5.0.0`에서 `5.0.2`로 변경
- `egovframe-boot-starter-parent`를 `5.0.0`에서 `5.0.1`로 변경
- 부모 BOM에서 관리하는 다음 의존성의 개별 버전 속성 및 선언 제거
  - Log4j 2
  - SLF4J
  - Log4jdbc
  - HikariCP
  - Commons BeanUtils
  - Commons Lang 3
- Tomcat 보안 취약점 대응 버전을 `10.1.59`로 재정의
- Tomcat 관련 직접 의존성도 공통 `tomcat.version`을 통해 관리

## 영향 범위

- Maven 빌드 및 의존성 해석
- eGovFrame/Spring Boot 기반 라이브러리 버전
- 애플리케이션 API 및 동작의 의도적인 변경 없음
- 단절적 변경 없음

## 테스트

다음 환경에서 전체 테스트를 실행했습니다.

- Java: `17.0.17`
- Maven: `3.9.9`
- 명령: `mvn -Dmaven.repo.local=D:\eGovCI-5.0.0-Windows-64bit.m2\repository test`

결과:

- 전체 208개 테스트 실행
- 실패 0개
- 오류 1개
- `TestEgovLoginApiControllerSelenium.test`가
  `http://localhost:3000/login` 연결 거부로 오류 발생
- 나머지 테스트는 통과
- 컴파일 및 Spring Boot 애플리케이션 컨텍스트 로딩 정상

https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
