### PR TITLE
fix(member): 비밀번호 생략 시 회원정보 수정 오류 방지

### DIFF
--- a/src/main/java/egovframework/let/uss/umt/service/impl/EgovMberManageServiceImpl.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/EgovMberManageServiceImpl.java
@@ -101,10 +101,8 @@ public class EgovMberManageServiceImpl extends EgovAbstractServiceImpl implement
 	 */
 	@Override
 	public void updateMber(MberManageVO mberManageVO) throws Exception {
-		//패스워드 암호화
-		if(mberManageVO.getPassword().isEmpty() || mberManageVO.getPassword().equals("")) {
-			//업데이트 시 암호가 공백이면 암호화 과정 건너띈다.
-		} else {
+		// 비밀번호를 입력한 경우에만 암호화한다.
+		if (mberManageVO.getPassword() != null && !mberManageVO.getPassword().isEmpty()) {
 			// 저장 형식 = 이중해시
 			String pass = EgovFileScrty.encryptPasswordTwice(mberManageVO.getPassword(), mberManageVO.getMberId());
 			mberManageVO.setPassword(pass);

--- a/src/test/java/egovframework/let/uss/umt/service/impl/EgovMberOptionalPasswordTest.java
+++ b/src/test/java/egovframework/let/uss/umt/service/impl/EgovMberOptionalPasswordTest.java
@@ -1,0 +1,117 @@
+package egovframework.let.uss.umt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.utl.sim.service.EgovFileScrty;
+import egovframework.let.uss.umt.web.EgovMberManageApiController;
+
+/** 실제 컨트롤러·서비스·DAO·HSQL 매퍼를 연결한다. 인증 필터는 포함하지 않는다. */
+class EgovMberOptionalPasswordTest {
+
+	private EmbeddedDatabase database;
+	private JdbcTemplate jdbc;
+	private MockMvc mvc;
+	private String originalHash;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		database = new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.HSQL)
+				.setName("member-" + UUID.randomUUID()).build();
+		jdbc = new JdbcTemplate(database);
+		jdbc.execute("CREATE TABLE LETTNEMPLYRINFO (ESNTL_ID VARCHAR(30) PRIMARY KEY, "
+				+ "EMPLYR_ID VARCHAR(30), USER_NM VARCHAR(60), PASSWORD VARCHAR(200), "
+				+ "ORGNZT_ID VARCHAR(30), PASSWORD_HINT VARCHAR(30), PASSWORD_CNSR VARCHAR(100), "
+				+ "IHIDNUM VARCHAR(30), SEXDSTN_CODE VARCHAR(10), ZIP VARCHAR(10), HOUSE_ADRES VARCHAR(100), "
+				+ "AREA_NO VARCHAR(10), EMPLYR_STTUS_CODE VARCHAR(10), DETAIL_ADRES VARCHAR(100), "
+				+ "HOUSE_END_TELNO VARCHAR(10), MBTLNUM VARCHAR(30), GROUP_ID VARCHAR(30), "
+				+ "FXNUM VARCHAR(30), EMAIL_ADRES VARCHAR(100), HOUSE_MIDDLE_TELNO VARCHAR(10), SBSCRB_DE TIMESTAMP)");
+		originalHash = EgovFileScrty.encryptPasswordTwice("Original123", "reviewuser");
+		jdbc.update("INSERT INTO LETTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, USER_NM, PASSWORD, EMPLYR_STTUS_CODE) "
+				+ "VALUES (?, ?, ?, ?, ?)", "MEMBER_REVIEW", "reviewuser", "기존 이름", originalHash, "P");
+		SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+		factory.setDataSource(database);
+		org.apache.ibatis.session.Configuration configuration = new org.apache.ibatis.session.Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("mberVO", egovframework.let.uss.umt.service.MberManageVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("userSearchVO", egovframework.let.uss.umt.service.UserDefaultVO.class);
+		factory.setConfiguration(configuration);
+		factory.setMapperLocations(new ClassPathResource("egovframework/mapper/let/uss/umt/EgovMberManage_SQL_hsql.xml"));
+		MberManageDAO dao = new MberManageDAO();
+		dao.setSqlSessionTemplate(new SqlSessionTemplate(factory.getObject()));
+		EgovMberManageServiceImpl service = new EgovMberManageServiceImpl();
+		ReflectionTestUtils.setField(service, "mberManageDAO", dao);
+		EgovMberManageApiController controller = new EgovMberManageApiController(service,
+				mock(EgovCmmUseService.class), mock(EgovPropertyService.class), new ResultVoHelper());
+		mvc = MockMvcBuilders.standaloneSetup(controller).setCustomArgumentResolvers(new HandlerMethodArgumentResolver() {
+			@Override
+			public boolean supportsParameter(MethodParameter parameter) {
+				return parameter.getParameterType() == LoginVO.class;
+			}
+			@Override
+			public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer container,
+					NativeWebRequest request, WebDataBinderFactory binderFactory) {
+				LoginVO user = new LoginVO();
+				user.setUniqId("MEMBER_REVIEW");
+				return user;
+			}
+		}).build();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (database != null) database.shutdown();
+	}
+
+	@ParameterizedTest(name = "{0}: password {1}")
+	@MethodSource("requests")
+	void updatesOtherFieldsAndOnlyChangesPasswordWhenProvided(String endpoint, String label,
+			String passwordJson, boolean changed) throws Exception {
+		String body = "{\"uniqId\":\"MEMBER_REVIEW\",\"mberId\":\"reviewuser\",\"mberNm\":\"수정 이름\","
+				+ "\"mberSttus\":\"P\",\"groupId\":\"GROUP_00000000000001\"" + passwordJson + "}";
+		mvc.perform(put(endpoint).contentType(MediaType.APPLICATION_JSON).content(body))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.resultCode").value(200));
+		assertEquals("수정 이름", jdbc.queryForObject("SELECT USER_NM FROM LETTNEMPLYRINFO", String.class));
+		assertEquals(changed ? EgovFileScrty.encryptPasswordTwice("Changed123", "reviewuser") : originalHash,
+				jdbc.queryForObject("SELECT PASSWORD FROM LETTNEMPLYRINFO", String.class));
+	}
+
+	static Stream<Arguments> requests() {
+		return Stream.of("/members/update", "/mypage/update").flatMap(endpoint -> Stream.of(
+				Arguments.of(endpoint, "생략", "", false),
+				Arguments.of(endpoint, "null", ",\"password\":null", false),
+				Arguments.of(endpoint, "빈 문자열", ",\"password\":\"\"", false),
+				Arguments.of(endpoint, "새 비밀번호", ",\"password\":\"Changed123\"", true)));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

회원정보 수정 요청에서 password를 생략하거나 null로 전달하면 isEmpty() 호출에서 NullPointerException이 발생했습니다.

## 수정된 소스 내용 Modified source

비밀번호가 null 또는 빈 문자열이면 암호화를 건너뛰고 다른 정보를 수정합니다. 새 비밀번호의 기존 이중 해싱 방식은 유지합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing


JUnit 14건이 통과했습니다. 관리자·내 정보 수정 API에서 생략/null/빈 문자열일 때 기존 해시 유지, 새 비밀번호 해싱, 이름의 DB 반영을 확인했습니다.

MockMvc부터 실제 서비스·DAO·MyBatis 매퍼·메모리 HSQL DB까지 연결했습니다. 인증 필터와 다른 DB의 비밀번호 UPDATE 누락은 이번 범위에 포함하지 않았습니다.

```sh
mvn -Dtest=EgovMberOptionalPasswordTest,EgovMberManageApiControllerTest test
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

자동 테스트로 확인했으며 별도 화면 캡처는 없습니다.

```text
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
