### PR TITLE
fix(schedule): 일정 날짜와 기간의 서버 검증 추가

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageApiController.java
@@ -1,6 +1,10 @@
 package egovframework.let.cop.smt.sim.web;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Calendar;
@@ -65,6 +69,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Tag(name="EgovIndvdlSchdulManageApiController",description = "일정관리")
 public class EgovIndvdlSchdulManageApiController {
+	private static final DateTimeFormatter SCHEDULE_DATE_FORMAT = DateTimeFormatter
+			.ofPattern("uuuuMMddHHmmss").withResolverStyle(ResolverStyle.STRICT);
+
 	private final EgovIndvdlSchdulManageService egovIndvdlSchdulManageService;
 	private final EgovCmmUseService cmmUseService;
 	private final EgovFileMngService fileMngService;
@@ -173,7 +180,7 @@ public class EgovIndvdlSchdulManageApiController {
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginVO loginVO
 	) throws Exception {
 
-		if (bindingResult.hasErrors()) {
+		if (bindingResult.hasErrors() || !isValidSchedulePeriod(indvdlSchdulManageVO)) {
 			return resultVoHelper.buildFromResultVO(new ResultVO(), ResponseCode.INPUT_CHECK_ERROR);
 		}
 
@@ -340,7 +347,7 @@ public class EgovIndvdlSchdulManageApiController {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 
 		indvdlSchdulManageVO.setSchdulId(schdulId);
-		if (bindingResult.hasErrors()) {
+		if (bindingResult.hasErrors() || !isValidSchedulePeriod(indvdlSchdulManageVO)) {
 			return resultVoHelper.buildFromMap(resultMap, ResponseCode.INPUT_CHECK_ERROR);
 		}
 
@@ -385,6 +392,21 @@ public class EgovIndvdlSchdulManageApiController {
 		egovIndvdlSchdulManageService.updateIndvdlSchdulManage(indvdlSchdulManageVO);
 
 		return resultVoHelper.buildFromMap(resultMap, ResponseCode.SUCCESS);
+	}
+
+	private boolean isValidSchedulePeriod(IndvdlSchdulManageVO schedule) {
+		String begin = schedule.getSchdulBgnde();
+		String end = schedule.getSchdulEndde();
+		if (begin == null || end == null || !begin.matches("[0-9]{14}") || !end.matches("[0-9]{14}")) {
+			return false;
+		}
+		try {
+			LocalDateTime beginDate = LocalDateTime.parse(begin, SCHEDULE_DATE_FORMAT);
+			LocalDateTime endDate = LocalDateTime.parse(end, SCHEDULE_DATE_FORMAT);
+			return beginDate.getYear() > 0 && endDate.getYear() > 0 && !beginDate.isAfter(endDate);
+		} catch (DateTimeParseException e) {
+			return false;
+		}
 	}
 
 	/**

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovSchedulePeriodValidationTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovSchedulePeriodValidationTest.java
@@ -1,0 +1,131 @@
+package egovframework.let.cop.smt.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovFileMngUtil;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.util.ResultVoHelper;
+import egovframework.let.cop.smt.sim.service.EgovIndvdlSchdulManageService;
+import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+class EgovSchedulePeriodValidationTest {
+
+	private EgovIndvdlSchdulManageService service;
+	private EgovFileMngService fileService;
+	private EgovFileMngUtil fileUtil;
+	private MockMvc mvc;
+
+	@BeforeEach
+	void setUp() {
+		service = mock(EgovIndvdlSchdulManageService.class);
+		fileService = mock(EgovFileMngService.class);
+		fileUtil = mock(EgovFileMngUtil.class);
+		EgovIndvdlSchdulManageApiController controller = new EgovIndvdlSchdulManageApiController(service,
+				mock(EgovCmmUseService.class), fileService, fileUtil, mock(EgovCryptoService.class), new ResultVoHelper());
+		mvc = MockMvcBuilders.standaloneSetup(controller).setCustomArgumentResolvers(new HandlerMethodArgumentResolver() {
+			@Override
+			public boolean supportsParameter(MethodParameter parameter) {
+				return parameter.getParameterType() == LoginVO.class;
+			}
+			@Override
+			public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer container,
+					NativeWebRequest request, WebDataBinderFactory binderFactory) {
+				LoginVO user = new LoginVO();
+				user.setUniqId("SCHEDULE_REVIEW_USER");
+				return user;
+			}
+		}).build();
+	}
+
+	@ParameterizedTest(name = "{0}: {1} ~ {2}")
+	@MethodSource("invalidPeriods")
+	void rejectsInvalidPeriodBeforeSavingScheduleOrAttachment(HttpMethod method, String begin, String end) throws Exception {
+		mvc.perform(request(method, begin, end).file(attachment()))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.resultCode").value(900));
+		verifyNoInteractions(service, fileService, fileUtil);
+	}
+
+	@ParameterizedTest(name = "{0}: {1} ~ {2}, attachment={3}")
+	@MethodSource("validPeriods")
+	void acceptsValidPeriodWithoutChangingItsValues(HttpMethod method, String begin, String end, boolean attachment) throws Exception {
+		MockMultipartHttpServletRequestBuilder request = request(method, begin, end);
+		if (attachment) {
+			request.file(attachment());
+			when(fileUtil.parseFileInf(any(), any(), any(Integer.class), any(), any())).thenReturn(List.of(new FileVO()));
+			when(fileService.insertFileInfs(any())).thenReturn("FILE_REVIEW");
+		}
+		mvc.perform(request).andExpect(status().isOk()).andExpect(jsonPath("$.resultCode").value(200));
+		ArgumentCaptor<IndvdlSchdulManageVO> saved = ArgumentCaptor.forClass(IndvdlSchdulManageVO.class);
+		if (method == HttpMethod.POST) verify(service).insertIndvdlSchdulManage(saved.capture());
+		else verify(service).updateIndvdlSchdulManage(saved.capture());
+		assertEquals(begin, saved.getValue().getSchdulBgnde());
+		assertEquals(end, saved.getValue().getSchdulEndde());
+		assertEquals("SCHEDULE_REVIEW_USER", saved.getValue().getLastUpdusrId());
+		if (attachment) {
+			verify(fileService).insertFileInfs(any());
+			assertEquals("FILE_REVIEW", saved.getValue().getAtchFileId());
+		} else verifyNoInteractions(fileService, fileUtil);
+	}
+
+	private static MockMultipartHttpServletRequestBuilder request(HttpMethod method, String begin, String end) {
+		MockMultipartHttpServletRequestBuilder request = multipart(method,
+				method == HttpMethod.POST ? "/schedule" : "/schedule/SCHDUL_REVIEW");
+		if (begin != null) request.param("schdulBgnde", begin);
+		if (end != null) request.param("schdulEndde", end);
+		request.param("schdulNm", "기간 검증").param("schdulCn", "검증 내용");
+		return request;
+	}
+
+	private static MockMultipartFile attachment() {
+		return new MockMultipartFile("file_0", "schedule.txt", "text/plain", new byte[] { 1 });
+	}
+
+	static Stream<Arguments> invalidPeriods() {
+		String normal = "20260913090000";
+		return Stream.of(HttpMethod.POST, HttpMethod.PUT).flatMap(method -> Stream.concat(
+				Stream.of(Arguments.of(method, "20260913100000", normal)),
+				Stream.of(null, "", "bad-date", "202609130900", "202609130900000", " 20260913090000", "20260913090000x",
+						"20260230090000", "20260229090000", "20261313090000", "20260013090000", "20260900090000",
+						"20260913240000", "20260913096000", "20260913090060", "00000913090000")
+						.flatMap(invalid -> Stream.of(Arguments.of(method, invalid, normal), Arguments.of(method, normal, invalid)))));
+	}
+
+	static Stream<Arguments> validPeriods() {
+		return Stream.of(HttpMethod.POST, HttpMethod.PUT).flatMap(method -> Stream.of(false, true).flatMap(attachment -> Stream.of(
+				Arguments.of(method, "20260913090000", "20260913100000", attachment),
+				Arguments.of(method, "20260913000000", "20260913000000", attachment),
+				Arguments.of(method, "20240229090000", "20240301090000", attachment),
+				Arguments.of(method, "20261231235959", "20270101000000", attachment))));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

일정 등록·수정 API에 종료가 시작보다 빠른 기간이나 존재하지 않는 날짜를 전달해도 저장 서비스가 호출됐습니다.

## 수정된 소스 내용 Modified source

React가 보내는 14자리 날짜·시각의 유효성과 시작 ≤ 종료를 검사합니다. 잘못된 입력에는 기존 resultCode 900을 반환하고 첨부파일·일정 저장을 호출하지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing


JUnit 94건이 통과했습니다. 잘못된 날짜·시각·길이·기간의 저장 차단과 정상 기간, 시작=종료, 윤년·연도 경계, 첨부파일 유무를 확인했습니다.

MockMvc multipart POST/PUT 요청으로 검증했으며 파일·일정 서비스는 대역입니다. 실제 DB·디스크 저장과 브라우저 통합 테스트는 수행하지 않았습니다. API 입력은 yyyyMMddHHmmss 14자리 형식을 사용해야 합니다.

```sh
mvn '-Dtest=EgovSchedulePeriodValidationTest,EgovIndvdlSchdulManageApiController*Test' test
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

자동 테스트로 확인했으며 별도 화면 캡처는 없습니다.

```text
Tests run: 94, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
